### PR TITLE
Merkle path instruction improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distaff"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Bobbin Threadbare <bobbinth@protonmail.com>"]
 edition = "2018"
 description="Zero-knowledge virtual machine written in Rust"
@@ -19,12 +19,12 @@ harness = false
 [dependencies]
 hex = "0.4.2"
 rand = "0.7.3"
-blake3 = "0.3.4"
+blake3 = "0.3.5"
 sha3 = "0.8.2"
 crossbeam-utils = "0.7.2"
 bincode = "1.3.1"
 serde = { version = "1.0.114", features = ["derive"] }
-log = "0.4.8"
+log = "0.4.11"
 env_logger = "0.7.1"
 
 [dev-dependencies]

--- a/docs/assembly.md
+++ b/docs/assembly.md
@@ -162,8 +162,8 @@ Divisions in prime fields are defined as inverse of multiplication. Specifically
 | ne        | Pops top two items from the stack, compares them, and if their values are not equal, pushes `1` onto the stack; otherwise pushes `0` onto the stack. | 3 |
 | gt.*n*    | Pops top two items from the stack, compares them, and if the 1st value is greater than the 2nd value, pushes `1` onto the stack; otherwise pushes `0` onto the stack. If either of the values is greater than 2<sup>*n*</sup>, the operation fails. *n* can be any integer between 4 and 128. | *n + 14* |
 | lt.*n*    | Pops top two items from the stack, compares them, and if the 1st value is less than the 2nd value, pushes `1` onto the stack; otherwise pushes `0` onto the stack. If either of the values is greater than 2<sup>*n*</sup>, the operation fails. *n* can be any integer between 4 and 128. | *n + 13* |
-| rc.*n*    | Pops the top item from the stack, checks if it is less than 2<sup>*n*</sup>, and if it is, pushes `1` onto the stack; otherwise pushes `0` onto the stack. *n* can be any integer between 4 and 128.| *n + 6* |
-| isodd.*n* | Pops the top item from the stack, and if its value is odd, pushes `1` onto the stack; otherwise pushes `0` onto the stack. If the value is greater than 2<sup>*n*</sup>, the operation fails. *n* can be any integer between 4 and 128. | *n + 5* |
+| rc.*n*    | Pops the top item from the stack, checks if it is less than 2<sup>*n*</sup>, and if it is, pushes `1` onto the stack; otherwise pushes `0` onto the stack. *n* can be any integer between 4 and 128.| *n + 8* |
+| isodd.*n* | Pops the top item from the stack, and if its value is odd, pushes `1` onto the stack; otherwise pushes `0` onto the stack. If the value is greater than 2<sup>*n*</sup>, the operation fails. *n* can be any integer between 4 and 128. | *n + 9* |
 
 ### Selection instructions
 

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -78,7 +78,7 @@ User instructions can be executed only concurrently with the `HACC` system instr
 | ----------- | :------: | -------------------------------------- |
 | EQ          |  1100010 | Pops top 3 values from the stack, subtracts the 3rd value from the 2nd, then multiplies the result by the 1st value, and then subtracts the result from value `1` and pushes the final result onto the stack. The operation can be used to check whether two values are equal (see [here](#Checking-equality)). |
 | CMP         |  0111111 | Pops top 8 items from the top of the stack, performs a single round of binary comparison, and pushes the resulting 8 values onto the stack. This operation can be used as a building block for *less then* and *greater than* operations (see [here](#Checking-inequality)). |
-| BINACC      |  1111101 | Pops top 3 items from the top of the stack, performs a single round of binary aggregation, and pushes the resulting 3 values onto the stack. This operation can be used as a building block for range check operations (see [here](#Checking-binary-decomposition)). |
+| BINACC      |  1111101 | Pops top 4 items from the top of the stack, performs a single round of binary aggregation, and pushes the resulting 4 values onto the stack. This operation can be used as a building block for range check operations (see [here](#Checking-binary-decomposition)). |
 
 ### Selection instructions
 
@@ -163,7 +163,7 @@ Each execution of the operation consumes a single input from tape `A`. The tape 
 Also similar to `CMP` operation, `BINACC` operation expect items on the stack to be arranged in a certain order. If the items are not arranged as shown below, the result of the operation is undefined:
 
 ```
-[p, 0, 0, a]
+[0, 0, p, 0, a]
 ```
 where:
   * `a` is the value we want to range-check,
@@ -171,7 +171,7 @@ where:
 
 Once items on the stack have been arranged as described above, we execute `BINACC` instruction `n` times. This will leave the stack in the following form:
 ```
-[x, x, a_acc, a]
+[x, x, x, a_acc, a]
 ```
 where:
 * `x` value is an intermediate results of executing `BINACC` operations and should be discarded.
@@ -179,9 +179,9 @@ where:
 
 To make sure that `a` can fit into `n` bits we need to check that `a_acc = a`. This can be done using the following sequence of operations:
 ```
-DROP DROP READ EQ
+DUP DROP4 READ EQ
 ```
-The above sequence discards the first two items, then checks the equality of the remaining two items as described [here](#Checking-equality) placing `1` onto the stack if the values are equal, and `0` otherwise.
+The above sequence discards the first three items, then checks the equality of the remaining two items as described [here](#Checking-equality) placing `1` onto the stack if the values are equal, and `0` otherwise.
 
 Overall, the number of operations needed to determine whether a value can be represented by `n` bits is `n + 4` (assuming you already have the value positioned correctly on the stack). Specifically:
 

--- a/docs/isa.md
+++ b/docs/isa.md
@@ -56,6 +56,7 @@ User instructions can be executed only concurrently with the `HACC` system instr
 | DROP4       |  1100100 | Removes top four items from the stack. |
 | SWAP        |  1111000 | Moves the second from the top stack item to the top of the stack (swaps top two stack items). |
 | SWAP2       |  1111001 | Moves 3rd and 4th stack items to the top of the stack. For example, assuming `S0` is the top of the stack, `S0 S1 S2 S3` becomes `S2 S3 S0 S1`. |
+| CSWAP2      |  1100111 | If the 5th stack item is `1`, swaps top 2 stack items (similar to `SWAP2` instructions); if the 5th stack item is `0`, the top 4 stack items remain unchanged; otherwise the operation fails. Stack items 5 and 6 are discarded. |
 | SWAP4       |  1111010 | Moves 5th through 8th stack items to the top of the stack. For example, assuming `S0` is the top of the stack, `S0 S1 S2 S3 S4 S5 S6 S7` becomes `S4 S5 S6 S7 S0 S1 S2 S3`. |
 | ROLL4       |  1111011 | Moves 4th stack item to the top of the stack. For example, assuming `S0` is the top of the stack, `S0 S1 S2 S3` becomes `S3 S0 S1 S2`.  |
 | ROLL8       |  1111100 | Moves 8th stack item to the top of the stack. For example, assuming `S0` is the top of the stack, `S0 S1 S2 S3 S4 S5 S6 S7` becomes `S7 S0 S1 S2 S3 S4 S5 S6`. |
@@ -158,23 +159,21 @@ Sometimes it may be useful to check whether a value fits into a certain number o
 
 Similar to `CMP` operation, `BINACC` operation needs to be executed `n` times in a row if we want to make sure that a value can be represented with `n` bits.
 
-Each execution of the operation consumes a single input from tape `A`. The tape must be populated with binary representation of value `a` in [big-endian](https://en.wikipedia.org/wiki/Endianness) order. For example, if `a = 5`, input tape `A` should be `[0, 1, 0, 1]`.
+Each execution of the operation consumes a single input from tape `A`. The tape must be populated with binary representation of value `a` in [little-endian](https://en.wikipedia.org/wiki/Endianness) order. For example, if `a = 5`, input tape `A` should be `[1, 0, 1, 0]`.
 
 Also similar to `CMP` operation, `BINACC` operation expect items on the stack to be arranged in a certain order. If the items are not arranged as shown below, the result of the operation is undefined:
 
 ```
-[0, 0, p, 0, a]
+[0, 0, 1, 0, a]
 ```
-where:
-  * `a` is the value we want to range-check,
-  * `p` is equal to 2<sup>n - 1</sup>.
+where `a` is the value we want to range-check,
 
 Once items on the stack have been arranged as described above, we execute `BINACC` instruction `n` times. This will leave the stack in the following form:
 ```
 [x, x, x, a_acc, a]
 ```
 where:
-* `x` value is an intermediate results of executing `BINACC` operations and should be discarded.
+* `x` values are intermediate results of executing `BINACC` operations and should be discarded.
 * `a_acc` will be equal the result of aggregating value `a` from its binary representation.
 
 To make sure that `a` can fit into `n` bits we need to check that `a_acc = a`. This can be done using the following sequence of operations:

--- a/src/examples/comparison.rs
+++ b/src/examples/comparison.rs
@@ -8,10 +8,10 @@ pub fn get_example(args: &[String]) -> Example  {
 
     // determine the expected result
     let expected_result: u128 = if value < 9 {
-        field::mul(9, value as u128) & 1
+        field::mul(9, value as u128)
     }
     else {
-        field::add(9, value as u128) & 1
+        field::add(9, value as u128)
     };
     
     // construct the program which checks if the value provided via secret inputs is
@@ -28,6 +28,7 @@ pub fn get_example(args: &[String]) -> Example  {
         else
             add
         end
+        dup
         isodd.128
     end").unwrap();
 
@@ -38,13 +39,13 @@ pub fn get_example(args: &[String]) -> Example  {
     let inputs = ProgramInputs::new(&[], &[value as u128], &[]);
 
     // a single element from the top of the stack will be the output
-    let num_outputs = 1;
+    let num_outputs = 2;
 
     return Example {
         program,
         inputs,
         options,
-        expected_result: vec![expected_result],
+        expected_result: vec![expected_result & 1, expected_result],
         num_outputs
     };
 }

--- a/src/examples/merkle.rs
+++ b/src/examples/merkle.rs
@@ -42,7 +42,7 @@ fn generate_merkle_program(n: usize) -> Program {
     let source = format!("
     begin
         read.ab
-        mpath.{}
+        smpath.{}
     end
     ", n);
 
@@ -63,15 +63,15 @@ fn generate_program_inputs(path: &[Vec<u128>; 2], index: usize) -> ProgramInputs
     b.push(path[1][0]);
 
     for i in 1..n {
-        // push the next node onto tapes A and B
-        a.push(path[0][i]);
-        b.push(path[1][i]);
-
         // push next bit of the position index onto tapes A and B; we use both tapes
         // here so that we can use READ2 instruction when reading inputs from the tapes
         a.push(field::ZERO);
         b.push((index & 1) as u128);
         index = index >> 1;
+
+        // push the next node onto tapes A and B
+        a.push(path[0][i]);
+        b.push(path[1][i]);
     }
 
     return ProgramInputs::new(&[], &a, &b);

--- a/src/examples/merkle.rs
+++ b/src/examples/merkle.rs
@@ -6,10 +6,6 @@ pub fn get_example(args: &[String]) -> Example  {
     // get the length of Merkle authentication path and proof options from the arguments
     let (depth, options) = parse_args(args);
     assert!(depth >= 2, "tree depth must be at least 2, but received {}", depth);
-    
-    // generate the program to verify Merkle path of given length
-    let program = generate_merkle_program(depth);
-    println!("Generated a program to verify Merkle proof for a tree of depth {}", depth);
 
     // generate a pseudo-random Merkle authentication path
     let (auth_path, leaf_index) = generate_authentication_path(depth);
@@ -17,14 +13,20 @@ pub fn get_example(args: &[String]) -> Example  {
     // compute root of the Merkle tree to which the path resolves
     let mut expected_result = compute_merkle_root(&auth_path, leaf_index);
     println!("Expected tree root: {:?}", expected_result);
+    
+    // generate the program to verify Merkle path of given length
+    let program = generate_merkle_program(depth, leaf_index);
+    println!("Generated a program to verify Merkle proof for a tree of depth {}", depth);
 
     // transform Merkle path into a set of inputs for the program
     let inputs = generate_program_inputs(&auth_path, leaf_index);
 
-    // a single element from the top of the stack will be the output
-    let num_outputs = 2;
+    // 4 element at the top of the stack will be the output
+    let num_outputs = 4;
 
-    // reverse tree root because values on the stack are in reverse order
+    // double and reverse tree root because values on the stack are in reverse order
+    expected_result.push(expected_result[0]);
+    expected_result.push(expected_result[1]);
     expected_result.reverse();
 
     return Example {
@@ -36,15 +38,22 @@ pub fn get_example(args: &[String]) -> Example  {
     };
 }
 
-/// Returns a program to verify Merkle authentication path for a tree of depth `n`
-fn generate_merkle_program(n: usize) -> Program {
+/// Returns a program to verify Merkle authentication paths for a tree of depth `n`;
+/// the program first verifies the path using smpath operation, and then verifies
+/// the same path using pmpath operation.
+fn generate_merkle_program(n: usize, index: usize) -> Program {
 
     let source = format!("
     begin
         read.ab
+        dup.2
         smpath.{}
+        swap.2
+        push.{}
+        roll.4 swap swap.2
+        pmpath.{}
     end
-    ", n);
+    ", n, index, n);
 
     return assembly::compile(&source).unwrap();
 }
@@ -62,6 +71,7 @@ fn generate_program_inputs(path: &[Vec<u128>; 2], index: usize) -> ProgramInputs
     a.push(path[0][0]);
     b.push(path[1][0]);
 
+    // populate the tapes with inputs for smpath operation
     for i in 1..n {
         // push next bit of the position index onto tapes A and B; we use both tapes
         // here so that we can use READ2 instruction when reading inputs from the tapes
@@ -70,6 +80,12 @@ fn generate_program_inputs(path: &[Vec<u128>; 2], index: usize) -> ProgramInputs
         index = index >> 1;
 
         // push the next node onto tapes A and B
+        a.push(path[0][i]);
+        b.push(path[1][i]);
+    }
+
+    // populate the tapes with inputs for pmpath operation
+    for i in 1..n {
         a.push(path[0][i]);
         b.push(path[1][i]);
     }

--- a/src/processor/opcodes.rs
+++ b/src/processor/opcodes.rs
@@ -174,6 +174,7 @@ pub enum OpHint {
     EqStart,
     RcStart(u32),
     CmpStart(u32),
+    PmpathStart(u32),
     PushValue(u128),
     None,
 }
@@ -192,8 +193,9 @@ impl std::fmt::Display for OpHint {
         return match self {
             OpHint::EqStart          => write!(f, "::eq"),
             OpHint::RcStart(value)   => write!(f, ".{}", value),
-            OpHint::CmpStart(value)  => write!(f, ".{}", value),
-            OpHint::PushValue(value) => write!(f, "({})", value),
+            OpHint::CmpStart(value)     => write!(f, ".{}", value),
+            OpHint::PmpathStart(value)  => write!(f, ".{}", value),
+            OpHint::PushValue(value)    => write!(f, "({})", value),
             OpHint::None             => Ok(()),
         };
     }

--- a/src/processor/opcodes.rs
+++ b/src/processor/opcodes.rs
@@ -53,7 +53,7 @@ pub enum UserOps {
     Drop4       = 0b0_11_00100,         // left shift: 4
     Choose      = 0b0_11_00101,         // left shift: 2
     Choose2     = 0b0_11_00110,         // left shift: 4
-    //???       = 0b0_11_00111,
+    CSwap2      = 0b0_11_00111,         // left shift: 2
 
     Add         = 0b0_11_01000,         // left shift: 1
     Mul         = 0b0_11_01001,         // left shift: 1
@@ -148,6 +148,7 @@ impl std::fmt::Display for UserOps {
     
             UserOps::Choose     => write!(f, "choose"),
             UserOps::Choose2    => write!(f, "choose2"),
+            UserOps::CSwap2     => write!(f, "cswap2"),
     
             UserOps::Add        => write!(f, "add"),
             UserOps::Mul        => write!(f, "mul"),

--- a/src/processor/stack/mod.rs
+++ b/src/processor/stack/mod.rs
@@ -541,13 +541,15 @@ impl Stack {
                 assert!(self.depth >= 5, "stack underflow at step {}", self.step);
                 let val = self.registers[4][self.step - 1];
                 for i in 0..n {
-                    self.tape_a.push((val >> i) & 1);
+                    // most significant bit is pushed first
+                    self.tape_a.push((val >> (n - i - 1)) & 1);
                 }
             },
-            _ => {
+            OpHint::None => {
                 assert!(self.depth >= 4, "stack underflow at step {}", self.step);
                 assert!(self.tape_a.len() > 0, "attempt to read from empty tape A at step {}", self.step);
-            }
+            },
+            _ => panic!("execution hint {:?} is not valid for BINACC operation", hint)
         }
 
         // get the next bit of the value from tape A
@@ -560,12 +562,7 @@ impl Stack {
         assert!(power_of_two.is_power_of_two(),
             "expected 3rd value from the top of the stack at step {} to be a power of 2, but received {}",
             self.step, power_of_two);
-        let next_power_of_two = if power_of_two == 1 {
-                field::div(power_of_two, 2)
-            }
-            else {
-                power_of_two >> 1
-            };
+        let next_power_of_two = field::mul(power_of_two, 2);
 
         let acc = self.registers[3][self.step - 1];
 

--- a/src/processor/stack/mod.rs
+++ b/src/processor/stack/mod.rs
@@ -93,6 +93,7 @@ impl Stack {
 
             OpCode::Choose      => self.op_choose(),
             OpCode::Choose2     => self.op_choose2(),
+            OpCode::CSwap2      => self.op_cswap2(),
 
             OpCode::Add         => self.op_add(),
             OpCode::Mul         => self.op_mul(),
@@ -337,6 +338,27 @@ impl Stack {
             assert!(false, "CHOOSE2 on a non-binary condition at step {}", self.step);
         }
         self.shift_left(6, 4);
+    }
+
+    fn op_cswap2(&mut self) {
+        assert!(self.depth >= 6, "stack underflow at step {}", self.step);
+        let condition = self.registers[4][self.step - 1];
+        if condition == field::ZERO {
+            self.registers[0][self.step] = self.registers[0][self.step - 1];
+            self.registers[1][self.step] = self.registers[1][self.step - 1];
+            self.registers[2][self.step] = self.registers[2][self.step - 1];
+            self.registers[3][self.step] = self.registers[3][self.step - 1];
+        }
+        else if condition == field::ONE {
+            self.registers[0][self.step] = self.registers[2][self.step - 1];
+            self.registers[1][self.step] = self.registers[3][self.step - 1];
+            self.registers[2][self.step] = self.registers[0][self.step - 1];
+            self.registers[3][self.step] = self.registers[1][self.step - 1];
+        }
+        else {
+            assert!(false, "CSWAP2 on a non-binary condition at step {}", self.step);
+        }
+        self.shift_left(6, 2);
     }
 
     // ARITHMETIC AND BOOLEAN OPERATIONS

--- a/src/processor/stack/mod.rs
+++ b/src/processor/stack/mod.rs
@@ -488,14 +488,14 @@ impl Stack {
             OpHint::RcStart(n) => {
                 // if we are about to start range check sequence, push binary decompositions
                 // of the value onto tape A
-                assert!(self.depth >= 4, "stack underflow at step {}", self.step);
-                let val = self.registers[3][self.step - 1];
+                assert!(self.depth >= 5, "stack underflow at step {}", self.step);
+                let val = self.registers[4][self.step - 1];
                 for i in 0..n {
                     self.tape_a.push((val >> i) & 1);
                 }
             },
             _ => {
-                assert!(self.depth >= 3, "stack underflow at step {}", self.step);
+                assert!(self.depth >= 4, "stack underflow at step {}", self.step);
                 assert!(self.tape_a.len() > 0, "attempt to read from empty tape A at step {}", self.step);
             }
         }
@@ -506,9 +506,10 @@ impl Stack {
             "expected binary input at step {} but received: {}", self.step, bit);
 
         // compute current power of 2 for binary decomposition
-        let power_of_two = self.registers[0][self.step - 1];
+        let power_of_two = self.registers[2][self.step - 1];
         assert!(power_of_two.is_power_of_two(),
-            "expected top of the stack at step {} to be a power of 2, but received {}", self.step, power_of_two);
+            "expected 3rd value from the top of the stack at step {} to be a power of 2, but received {}",
+            self.step, power_of_two);
         let next_power_of_two = if power_of_two == 1 {
                 field::div(power_of_two, 2)
             }
@@ -516,14 +517,15 @@ impl Stack {
                 power_of_two >> 1
             };
 
-        let acc = self.registers[2][self.step - 1];
+        let acc = self.registers[3][self.step - 1];
 
         // update the next state of the computation
-        self.registers[0][self.step] = next_power_of_two;
-        self.registers[1][self.step] = bit;
-        self.registers[2][self.step] = field::add(acc, field::mul(bit, power_of_two));
+        self.registers[0][self.step] = bit;
+        self.registers[1][self.step] = 0;
+        self.registers[2][self.step] = next_power_of_two;
+        self.registers[3][self.step] = field::add(acc, field::mul(bit, power_of_two));
 
-        self.copy_state(3);
+        self.copy_state(4);
     }
 
     // CRYPTOGRAPHIC OPERATIONS

--- a/src/processor/stack/tests/comparisons.rs
+++ b/src/processor/stack/tests/comparisons.rs
@@ -184,7 +184,11 @@ fn binacc_128() {
     for i in 0..128 { inputs_a.push((x >> i) & 1); }
     inputs_a.reverse();
 
-    let mut stack = init_stack(&[p127, 0, 0, x, 7, 11], &inputs_a, &[], 256);
+    let mut stack = init_stack(
+        &[0, 0, p127, 0, x, 7, 11],
+        &inputs_a,
+        &[],
+        256);
 
     // execute binary aggregation operations
     for _ in 0..128 { stack.execute(OpCode::BinAcc, OpHint::None); }
@@ -192,7 +196,8 @@ fn binacc_128() {
     // check the result
     stack.execute(OpCode::Drop, OpHint::None);
     stack.execute(OpCode::Drop, OpHint::None);
-    let state = get_stack_state(&stack, 130);
+    stack.execute(OpCode::Drop, OpHint::None);
+    let state = get_stack_state(&stack, 131);
     assert_eq!(vec![x, x, 7, 11, 0, 0, 0, 0], state);
 }
 
@@ -207,7 +212,11 @@ fn binacc_64() {
     for i in 0..64 { inputs_a.push((x >> i) & 1); }
     inputs_a.reverse();
 
-    let mut stack = init_stack(&[p127, 0, 0, x, 7, 11], &inputs_a, &[], 256);
+    let mut stack = init_stack(
+        &[0, 0, p127, 0, x, 7, 11],
+        &inputs_a,
+        &[],
+        256);
 
     // execute binary aggregation operations
     for _ in 0..64 { stack.execute(OpCode::BinAcc, OpHint::None); }
@@ -215,7 +224,8 @@ fn binacc_64() {
     // check the result
     stack.execute(OpCode::Drop, OpHint::None);
     stack.execute(OpCode::Drop, OpHint::None);
-    let state = get_stack_state(&stack, 66);
+    stack.execute(OpCode::Drop, OpHint::None);
+    let state = get_stack_state(&stack, 67);
     assert_eq!(vec![x, x, 7, 11, 0, 0, 0, 0], state);
 }
 
@@ -231,16 +241,22 @@ fn isodd_128() {
     for i in 0..128 { inputs_a.push((x >> i) & 1); }
     inputs_a.reverse();
 
-    let mut stack = init_stack(&[p127, 0, 0, x, 7, 11], &inputs_a, &[], 256);
+    let mut stack = init_stack(
+        &[0, 0, p127, 0, x, 7, 11],
+        &inputs_a,
+        &[],
+        256);
 
     // execute binary aggregation operations
     for _ in 0..128 { stack.execute(OpCode::BinAcc, OpHint::None); }
 
     // check the result
     stack.execute(OpCode::Swap2, OpHint::None);
-    stack.execute(OpCode::AssertEq, OpHint::None);
     stack.execute(OpCode::Drop, OpHint::None);
-    let state = get_stack_state(&stack, 131);
+    stack.execute(OpCode::Swap2, OpHint::None);
+    stack.execute(OpCode::Drop, OpHint::None);
+    stack.execute(OpCode::AssertEq, OpHint::None);
+    let state = get_stack_state(&stack, 133);
     assert_eq!(vec![is_odd, 7, 11, 0, 0, 0, 0, 0], state);
 }
 

--- a/src/processor/stack/tests/conditional.rs
+++ b/src/processor/stack/tests/conditional.rs
@@ -1,0 +1,92 @@
+use super::{ init_stack, get_stack_state, OpCode, OpHint, TRACE_LENGTH };
+
+// CHOOSE OPERATIONS
+// ================================================================================================
+
+#[test]
+fn choose() {
+    // choose on false
+    let mut stack = init_stack(&[2, 3, 0], &[], &[], TRACE_LENGTH);
+    stack.execute(OpCode::Choose, OpHint::None);
+    assert_eq!(vec![3, 0, 0, 0, 0, 0, 0, 0], get_stack_state(&stack, 1));
+
+    assert_eq!(1, stack.depth);
+    assert_eq!(3, stack.max_depth);
+
+    let mut stack = init_stack(&[2, 3, 0, 4], &[], &[], TRACE_LENGTH);
+    stack.execute(OpCode::Choose, OpHint::None);
+    assert_eq!(vec![3, 4, 0, 0, 0, 0, 0, 0], get_stack_state(&stack, 1));
+
+    assert_eq!(2, stack.depth);
+    assert_eq!(4, stack.max_depth);
+
+    // choose on true
+    let mut stack = init_stack(&[2, 3, 1, 4], &[], &[], TRACE_LENGTH);
+    stack.execute(OpCode::Choose, OpHint::None);
+    assert_eq!(vec![2, 4, 0, 0, 0, 0, 0, 0], get_stack_state(&stack, 1));
+
+    assert_eq!(2, stack.depth);
+    assert_eq!(4, stack.max_depth);
+}
+
+#[test]
+#[should_panic(expected = "CHOOSE on a non-binary condition at step 1")]
+fn choose_fail() {
+    let mut stack = init_stack(&[2, 3, 4], &[], &[], TRACE_LENGTH);
+    stack.execute(OpCode::Choose, OpHint::None);
+}
+
+#[test]
+fn choose2() {
+    // choose on false
+    let mut stack = init_stack(&[2, 3, 4, 5, 0, 6, 7], &[], &[], TRACE_LENGTH);
+    stack.execute(OpCode::Choose2, OpHint::None);
+    assert_eq!(vec![4, 5, 7, 0, 0, 0, 0, 0], get_stack_state(&stack, 1));
+
+    assert_eq!(3, stack.depth);
+    assert_eq!(7, stack.max_depth);
+
+    // choose on true
+    let mut stack = init_stack(&[2, 3, 4, 5, 1, 6, 7], &[], &[], TRACE_LENGTH);
+    stack.execute(OpCode::Choose2, OpHint::None);
+    assert_eq!(vec![2, 3, 7, 0, 0, 0, 0, 0], get_stack_state(&stack, 1));
+
+    assert_eq!(3, stack.depth);
+    assert_eq!(7, stack.max_depth);
+}
+
+#[test]
+#[should_panic(expected = "CHOOSE2 on a non-binary condition at step 1")]
+fn choose2_fail() {
+    let mut stack = init_stack(&[2, 3, 4, 5, 6, 8, 8], &[], &[], TRACE_LENGTH);
+    stack.execute(OpCode::Choose2, OpHint::None);
+}
+
+// OTHER CONDITIONAL OPERATIONS
+// ================================================================================================
+
+#[test]
+fn cswap2() {
+    // don't swap on false
+    let mut stack = init_stack(&[2, 3, 4, 5, 0, 6, 7], &[], &[], TRACE_LENGTH);
+    stack.execute(OpCode::CSwap2, OpHint::None);
+    assert_eq!(vec![2, 3, 4, 5, 7, 0, 0, 0], get_stack_state(&stack, 1));
+
+    assert_eq!(5, stack.depth);
+    assert_eq!(7, stack.max_depth);
+
+    // swap on true
+    let mut stack = init_stack(&[2, 3, 4, 5, 1, 6, 7], &[], &[], TRACE_LENGTH);
+    stack.execute(OpCode::CSwap2, OpHint::None);
+    assert_eq!(vec![4, 5, 2, 3, 7, 0, 0, 0], get_stack_state(&stack, 1));
+
+    assert_eq!(5, stack.depth);
+    assert_eq!(7, stack.max_depth);
+}
+
+#[test]
+#[should_panic(expected = "CSWAP2 on a non-binary condition at step 1")]
+fn cswap2_fail() {
+    let mut stack = init_stack(&[2, 3, 4, 5, 6, 8, 8], &[], &[], TRACE_LENGTH);
+    stack.execute(OpCode::CSwap2, OpHint::None);
+}

--- a/src/processor/stack/tests/mod.rs
+++ b/src/processor/stack/tests/mod.rs
@@ -4,6 +4,7 @@ use super::{ Stack, super::ProgramInputs, OpHint, OpCode };
 use crate::{ HASH_STATE_WIDTH };
 
 mod comparisons;
+mod conditional;
 
 const TRACE_LENGTH: usize = 16;
 
@@ -212,68 +213,6 @@ fn roll8() {
 
     assert_eq!(8, stack.depth);
     assert_eq!(8, stack.max_depth);
-}
-
-// CONDITIONAL OPERATIONS
-// ================================================================================================
-
-#[test]
-fn choose() {
-    // choose on true
-    let mut stack = init_stack(&[2, 3, 0], &[], &[], TRACE_LENGTH);
-    stack.execute(OpCode::Choose, OpHint::None);
-    assert_eq!(vec![3, 0, 0, 0, 0, 0, 0, 0], get_stack_state(&stack, 1));
-
-    assert_eq!(1, stack.depth);
-    assert_eq!(3, stack.max_depth);
-
-    let mut stack = init_stack(&[2, 3, 0, 4], &[], &[], TRACE_LENGTH);
-    stack.execute(OpCode::Choose, OpHint::None);
-    assert_eq!(vec![3, 4, 0, 0, 0, 0, 0, 0], get_stack_state(&stack, 1));
-
-    assert_eq!(2, stack.depth);
-    assert_eq!(4, stack.max_depth);
-
-    // choose on false
-    let mut stack = init_stack(&[2, 3, 1, 4], &[], &[], TRACE_LENGTH);
-    stack.execute(OpCode::Choose, OpHint::None);
-    assert_eq!(vec![2, 4, 0, 0, 0, 0, 0, 0], get_stack_state(&stack, 1));
-
-    assert_eq!(2, stack.depth);
-    assert_eq!(4, stack.max_depth);
-}
-
-#[test]
-#[should_panic(expected = "CHOOSE on a non-binary condition at step 1")]
-fn choose_fail() {
-    let mut stack = init_stack(&[2, 3, 4], &[], &[], TRACE_LENGTH);
-    stack.execute(OpCode::Choose, OpHint::None);
-}
-
-#[test]
-fn choose2() {
-    // choose on true
-    let mut stack = init_stack(&[2, 3, 4, 5, 0, 6, 7], &[], &[], TRACE_LENGTH);
-    stack.execute(OpCode::Choose2, OpHint::None);
-    assert_eq!(vec![4, 5, 7, 0, 0, 0, 0, 0], get_stack_state(&stack, 1));
-
-    assert_eq!(3, stack.depth);
-    assert_eq!(7, stack.max_depth);
-
-    // choose on false
-    let mut stack = init_stack(&[2, 3, 4, 5, 1, 6, 7], &[], &[], TRACE_LENGTH);
-    stack.execute(OpCode::Choose2, OpHint::None);
-    assert_eq!(vec![2, 3, 7, 0, 0, 0, 0, 0], get_stack_state(&stack, 1));
-
-    assert_eq!(3, stack.depth);
-    assert_eq!(7, stack.max_depth);
-}
-
-#[test]
-#[should_panic(expected = "CHOOSE2 on a non-binary condition at step 1")]
-fn choose2_fail() {
-    let mut stack = init_stack(&[2, 3, 4, 5, 6, 8, 8], &[], &[], TRACE_LENGTH);
-    stack.execute(OpCode::Choose2, OpHint::None);
 }
 
 // ARITHMETIC AND BOOLEAN OPERATIONS

--- a/src/programs/assembly/mod.rs
+++ b/src/programs/assembly/mod.rs
@@ -237,6 +237,7 @@ fn parse_op_token(op: Vec<&str>, op_codes: &mut Vec<OpCode>, op_hints: &mut Hint
 
         "hash"   => parse_hash(op_codes, &op, step),
         "smpath" => parse_smpath(op_codes, &op, step),
+        "pmpath" => parse_pmpath(op_codes, op_hints, &op, step),
 
         _ => return Err(AssemblyError::invalid_op(&op, step))
     }?;

--- a/src/programs/assembly/mod.rs
+++ b/src/programs/assembly/mod.rs
@@ -236,7 +236,7 @@ fn parse_op_token(op: Vec<&str>, op_codes: &mut Vec<OpCode>, op_hints: &mut Hint
         "choose" => parse_choose(op_codes, &op, step),
 
         "hash"   => parse_hash(op_codes, &op, step),
-        "mpath"  => parse_mpath(op_codes, &op, step),
+        "smpath" => parse_smpath(op_codes, &op, step),
 
         _ => return Err(AssemblyError::invalid_op(&op, step))
     }?;

--- a/src/programs/assembly/parsers.rs
+++ b/src/programs/assembly/parsers.rs
@@ -460,11 +460,11 @@ pub fn parse_smpath(program: &mut Vec<OpCode>, op: &[&str], step: usize) -> Resu
     program.resize(program.len() + pad_length, OpCode::Noop);
 
     // repeat the following cycle of operations once for each remaining node:
-    // 1. computes hash of the 2 nodes on the stack
-    // 2. reads the index of the next node in the authentication path
-    // 3. reads the next node in the authentication path
-    // 4. base on position index bit = 1, swaps the nodes on the stack
-    // 5. pads the stack to prepare it for the next round of hashing
+    // 1. compute hash of the 2 nodes on the stack
+    // 2. read the index of the next node in the authentication path
+    // 3. read the next node in the authentication path
+    // 4. base on position index bit = 1, swaps the nodes on the stack (using cswap2 instruction)
+    // 5. pad the stack to prepare it for the next round of hashing
     const SUB_CYCLE: [OpCode; 16] = [
         OpCode::RescR, OpCode::RescR, OpCode::RescR,  OpCode::RescR,
         OpCode::RescR, OpCode::RescR, OpCode::RescR,  OpCode::RescR,
@@ -509,7 +509,11 @@ pub fn parse_pmpath(program: &mut Vec<OpCode>, hints: &mut HintMap, op: &[&str],
     program.resize(program.len() + pad_length, OpCode::Noop);
 
     // repeat the following cycle of operations once for each remaining node:
-    // 1. TODO
+    // 1. compute hash of the 2 nodes on the stack
+    // 2. read the index of the next node in the authentication path (using binacc instruction)
+    // 3. read the next node in the authentication path
+    // 4. base on position index bit = 1, swap the nodes on the stack (using cswap2 instruction)
+    // 5. pad the stack to prepare it for the next round of hashing
     const SUB_CYCLE: [OpCode; 32] = [
         OpCode::RescR, OpCode::RescR,  OpCode::RescR, OpCode::RescR,
         OpCode::RescR, OpCode::RescR,  OpCode::RescR, OpCode::RescR,
@@ -525,7 +529,8 @@ pub fn parse_pmpath(program: &mut Vec<OpCode>, hints: &mut HintMap, op: &[&str],
         program.extend_from_slice(&SUB_CYCLE);
     }
 
-    // TODO: add comment
+    // at the end, use the first 11 operations from the cycle since there is nothing else to read;
+    // then make sure the accumulated value of index is indeed equal to the leaf index
     program.extend_from_slice(&SUB_CYCLE[..11]);
     program.extend_from_slice(&[OpCode::Swap2, OpCode::Drop, OpCode::Roll4, OpCode::AssertEq]);
 

--- a/src/programs/assembly/parsers.rs
+++ b/src/programs/assembly/parsers.rs
@@ -352,7 +352,7 @@ pub fn parse_rc(program: &mut Vec<OpCode>, hints: &mut HintMap, op: &[&str], ste
     program.resize(program.len() + (n as usize), OpCode::BinAcc);
 
     // compare binary aggregation value with the original value
-    program.extend_from_slice(&[OpCode::Drop, OpCode::Drop]);
+    program.extend_from_slice(&[OpCode::Dup, OpCode::Drop4]);
     hints.insert(program.len(), OpHint::EqStart);
     program.extend_from_slice(&[OpCode::Read, OpCode::Eq]);
     return Ok(true);
@@ -382,7 +382,7 @@ pub fn parse_isodd(program: &mut Vec<OpCode>, hints: &mut HintMap, op: &[&str], 
 
     // compare binary aggregation value with the original value and drop all
     // values used in computations except for the least significant bit of the value
-    program.extend_from_slice(&[OpCode::Swap2, OpCode::AssertEq, OpCode::Drop]);
+    program.extend_from_slice(&[OpCode::Swap2, OpCode::Drop, OpCode::Swap2, OpCode::AssertEq]);
     return Ok(true);
 }
 

--- a/src/programs/assembly/parsers.rs
+++ b/src/programs/assembly/parsers.rs
@@ -344,6 +344,7 @@ pub fn parse_rc(program: &mut Vec<OpCode>, hints: &mut HintMap, op: &[&str], ste
     program.push(OpCode::Pad2);
     let power_of_two = u128::pow(2, n - 1);
     append_push_op(program, hints, power_of_two);
+    program.extend_from_slice(&[OpCode::Swap, OpCode::Dup]);
 
     // add a hint indicating that range-checking is about to start
     hints.insert(program.len(), OpHint::RcStart(n));
@@ -370,9 +371,10 @@ pub fn parse_isodd(program: &mut Vec<OpCode>, hints: &mut HintMap, op: &[&str], 
     }
 
     // prepare the stack
-    program.extend_from_slice(&[OpCode::Pad2]);
+    program.push(OpCode::Pad2);
     let power_of_two = u128::pow(2, n - 1);
     append_push_op(program, hints, power_of_two);
+    program.extend_from_slice(&[OpCode::Swap, OpCode::Dup]);
 
     // add a hint indicating that range-checking is about to start
     hints.insert(program.len(), OpHint::RcStart(n));
@@ -382,7 +384,7 @@ pub fn parse_isodd(program: &mut Vec<OpCode>, hints: &mut HintMap, op: &[&str], 
 
     // compare binary aggregation value with the original value and drop all
     // values used in computations except for the least significant bit of the value
-    program.extend_from_slice(&[OpCode::Swap2, OpCode::Drop, OpCode::Swap2, OpCode::AssertEq]);
+    program.extend_from_slice(&[OpCode::Swap2, OpCode::Drop, OpCode::Swap2, OpCode::Drop, OpCode::AssertEq]);
     return Ok(true);
 }
 

--- a/src/programs/assembly/tests.rs
+++ b/src/programs/assembly/tests.rs
@@ -129,7 +129,7 @@ fn single_if_else_with_suffix() {
         pad2 noop noop noop noop noop noop noop \
         push(32768) binacc.16 binacc binacc binacc binacc binacc binacc \
         binacc binacc binacc binacc binacc binacc binacc binacc \
-        binacc drop drop read::eq eq noop noop end";
+        binacc dup drop4 read::eq eq noop noop end";
 
     assert_eq!(expected, format!("{:?}", program));
 }

--- a/src/programs/assembly/tests.rs
+++ b/src/programs/assembly/tests.rs
@@ -131,7 +131,7 @@ fn single_if_else_with_suffix() {
                 noop noop noop noop noop noop noop \
             end \
             pad2 noop noop noop noop noop noop noop \
-            push(32768) swap dup binacc.16 binacc binacc binacc binacc \
+            push(1) swap dup binacc.16 binacc binacc binacc binacc \
             binacc binacc binacc binacc binacc binacc binacc binacc \
             binacc binacc binacc dup drop4 read::eq eq \
         end";

--- a/src/programs/assembly/tests.rs
+++ b/src/programs/assembly/tests.rs
@@ -118,18 +118,23 @@ fn single_if_else_with_suffix() {
     let program = super::compile(source).unwrap();
 
     let expected = "\
-        begin noop noop noop noop noop noop noop \
-        push(3) noop noop noop noop noop noop noop \
-        push(5) read noop noop noop noop noop noop \
-        noop noop noop noop noop noop noop if \
-        assert add dup mul noop noop noop noop \
-        noop noop noop noop noop noop noop else \
-        not assert mul dup add noop noop noop \
-        noop noop noop noop noop noop noop end \
-        pad2 noop noop noop noop noop noop noop \
-        push(32768) binacc.16 binacc binacc binacc binacc binacc binacc \
-        binacc binacc binacc binacc binacc binacc binacc binacc \
-        binacc dup drop4 read::eq eq noop noop end";
+        begin \
+            noop noop noop noop noop noop noop \
+            push(3) noop noop noop noop noop noop noop \
+            push(5) read noop noop noop noop noop noop \
+            noop noop noop noop noop noop noop \
+            if \
+                assert add dup mul noop noop noop noop \
+                noop noop noop noop noop noop noop \
+            else \
+                not assert mul dup add noop noop noop \
+                noop noop noop noop noop noop noop \
+            end \
+            pad2 noop noop noop noop noop noop noop \
+            push(32768) swap dup binacc.16 binacc binacc binacc binacc \
+            binacc binacc binacc binacc binacc binacc binacc binacc \
+            binacc binacc binacc dup drop4 read::eq eq \
+        end";
 
     assert_eq!(expected, format!("{:?}", program));
 }

--- a/src/stark/constraints/stack/comparison.rs
+++ b/src/stark/constraints/stack/comparison.rs
@@ -122,7 +122,7 @@ pub fn enforce_binacc(result: &mut [u128], old_stack: &[u128], new_stack: &[u128
 
     // power of 2 register was updated correctly
     let power_of_two = old_stack[2];
-    let power_of_two_constraint = are_equal(field::mul(new_stack[2], 2), power_of_two);
+    let power_of_two_constraint = are_equal(new_stack[2], field::mul(power_of_two, 2));
     result.agg_constraint(2, op_flag, power_of_two_constraint);
 
     // binary representation accumulator was updated correctly

--- a/src/stark/constraints/stack/conditional.rs
+++ b/src/stark/constraints/stack/conditional.rs
@@ -52,3 +52,32 @@ pub fn enforce_choose2(result: &mut [u128], aux: &mut [u128], old_stack: &[u128]
     // make sure the condition was a binary value
     aux.agg_constraint(0, op_flag, is_binary(condition));
 }
+
+/// Enforces constraints for CSWAP2 operation. These constraints work with top 6 registers of the
+/// stack and enforce that when condition = 1, (v2, v3) move to the top of the stack; when
+/// condition = 0, top 4 elements of the stack remain unchanged. 
+pub fn enforce_cswap2(result: &mut [u128], aux: &mut [u128], old_stack: &[u128], new_stack: &[u128], op_flag: u128) 
+{
+    let v0 = old_stack[0];
+    let v1 = old_stack[1];
+    let v2 = old_stack[2];
+    let v3 = old_stack[3];
+    let condition = old_stack[4];
+
+
+    let not_condition = binary_not(condition);
+    let op_result0 = field::add(field::mul(condition, v2), field::mul(not_condition, v0));
+    let op_result1 = field::add(field::mul(condition, v3), field::mul(not_condition, v1));
+    let op_result2 = field::add(field::mul(condition, v0), field::mul(not_condition, v2));
+    let op_result3 = field::add(field::mul(condition, v1), field::mul(not_condition, v3));
+    result.agg_constraint(0, op_flag, are_equal(new_stack[0], op_result0));
+    result.agg_constraint(1, op_flag, are_equal(new_stack[1], op_result1));
+    result.agg_constraint(2, op_flag, are_equal(new_stack[2], op_result2));
+    result.agg_constraint(3, op_flag, are_equal(new_stack[3], op_result3));
+
+    // registers beyond the 6th are shifted left by 2 slots
+    enforce_left_shift(result, old_stack, new_stack, 6, 2, op_flag);
+
+    // make sure the condition was a binary value
+    aux.agg_constraint(0, op_flag, is_binary(condition));
+}

--- a/src/stark/constraints/stack/mod.rs
+++ b/src/stark/constraints/stack/mod.rs
@@ -6,7 +6,7 @@ use crate::{
     BASE_CYCLE_LENGTH, HASH_STATE_WIDTH
 };
 use super::utils::{
-    are_equal, is_binary, binary_not, extend_constants, EvaluationResult,
+    are_equal, is_zero, is_binary, binary_not, extend_constants, EvaluationResult,
     enforce_stack_copy, enforce_left_shift, enforce_right_shift,
 };
 

--- a/src/stark/constraints/stack/mod.rs
+++ b/src/stark/constraints/stack/mod.rs
@@ -28,8 +28,8 @@ use manipulation::{
 mod comparison;
 use comparison::{ enforce_assert, enforce_asserteq, enforce_eq, enforce_cmp, enforce_binacc };
 
-mod selection;
-use selection::{ enforce_choose, enforce_choose2 };
+mod conditional;
+use conditional::{ enforce_choose, enforce_choose2, enforce_cswap2 };
 
 mod hash;
 use hash::{ enforce_rescr };
@@ -171,6 +171,7 @@ fn enforce_constraints(current: &TraceState, next: &TraceState, ark: &[u128], re
     // conditional selection operations
     enforce_choose  (&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::Choose.ld_index()]);
     enforce_choose2 (&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::Choose2.ld_index()]);
+    enforce_cswap2  (&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::CSwap2.ld_index()]);
 
     // 2 ----- enforce constraints for high-degree operations --------------------------------------
     let hd_flags = current.hd_op_flags();

--- a/src/tests/comparisons.rs
+++ b/src/tests/comparisons.rs
@@ -70,11 +70,10 @@ fn cmp_operation() {
 fn binacc_operation() {
 
     let a: u128 = field::rand();
-    let p127: u128 = field::exp(2, 127);
 
     // build inputs
     let mut inputs_a = Vec::new();
-    for i in 0..128 { inputs_a.push((a >> i) & 1); }
+    for i in 0..128 { inputs_a.push((a >> (127 - i)) & 1); }
     inputs_a.reverse();
 
     // build the program
@@ -89,7 +88,7 @@ fn binacc_operation() {
 
     let options = ProofOptions::default();
     let inputs = ProgramInputs::new(
-        &[0, 0, p127, 0, a],
+        &[0, 0, 1, 0, a],
         &inputs_a,
         &[]);
     let num_outputs = 2;

--- a/src/tests/comparisons.rs
+++ b/src/tests/comparisons.rs
@@ -82,12 +82,16 @@ fn binacc_operation() {
     for _ in 0..128 { instructions.push(OpCode::BinAcc); }
     instructions.push(OpCode::Drop);
     instructions.push(OpCode::Drop);
+    instructions.push(OpCode::Drop);
     while instructions.len() < 255 { instructions.push(OpCode::Noop); }
 
     let program = build_program(instructions, &[]);
 
     let options = ProofOptions::default();
-    let inputs = ProgramInputs::new(&[p127, 0, 0, a], &inputs_a, &[]);
+    let inputs = ProgramInputs::new(
+        &[0, 0, p127, 0, a],
+        &inputs_a,
+        &[]);
     let num_outputs = 2;
 
     let expected_result = vec![a, a];

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -87,7 +87,7 @@ fn stack_manipulation() {
 }
 
 #[test]
-fn selection_operations() {
+fn conditional_operations() {
     // CHOOSE
     let program = build_program(vec![
         OpCode::Begin, OpCode::Choose,  OpCode::Choose, OpCode::Noop,
@@ -124,6 +124,24 @@ fn selection_operations() {
 
     let (outputs, proof) = super::execute(&program, &inputs, num_outputs, &options);
     assert_eq!(outputs, [7, 8, 0, 0, 0, 0, 0, 0]);
+
+    let result = super::verify(program.hash(), inputs.get_public_inputs(), &outputs, &proof);
+    assert_eq!(Ok(true), result);
+
+    // CSWAP2
+    let program = build_program(vec![
+        OpCode::Begin,  OpCode::CSwap2,  OpCode::Pad2,   OpCode::Swap4,
+        OpCode::CSwap2, OpCode::Noop,    OpCode::Noop,   OpCode::Noop,
+        OpCode::Noop,   OpCode::Noop,    OpCode::Noop,   OpCode::Noop,
+        OpCode::Noop,   OpCode::Noop,    OpCode::Noop,
+    ], &[]);
+
+    let options = ProofOptions::default();
+    let inputs = ProgramInputs::from_public(&[3, 4, 1, 2, 1, 0, 5, 6]);
+    let num_outputs = 8;
+
+    let (outputs, proof) = super::execute(&program, &inputs, num_outputs, &options);
+    assert_eq!(outputs, [3, 4, 5, 6, 1, 2, 0, 0]);
 
     let result = super::verify(program.hash(), inputs.get_public_inputs(), &outputs, &proof);
     assert_eq!(Ok(true), result);


### PR DESCRIPTION
This PR will add a public variant of `mpath` assembly instructions. The tasks include:

- [x] Update semantics of `BINACC` VM instruction
- [x] Add `CSWAP2` VM instruction
- [x] Refactor `mpath` assembly instruction to use `CSWAP2` instruction and rename it to `smpath`
- [x] Add `pmpath` assembly instruction
- [x] Update documentation

