### PR TITLE
Random access memory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "distaff"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["Bobbin Threadbare <bobbinth@protonmail.com>"]
 edition = "2018"
 description="Zero-knowledge virtual machine written in Rust"
@@ -19,11 +19,11 @@ harness = false
 [dependencies]
 hex = "0.4.2"
 rand = "0.7.3"
-blake3 = "0.3.5"
+blake3 = "0.3.6"
 sha3 = "0.8.2"
 crossbeam-utils = "0.7.2"
 bincode = "1.3.1"
-serde = { version = "1.0.114", features = ["derive"] }
+serde = { version = "1.0.115", features = ["derive"] }
 log = "0.4.11"
 env_logger = "0.7.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,23 +109,20 @@ const HACC_NUM_ROUNDS       : usize = 14;
 // DECODER LAYOUT
 // ------------------------------------------------------------------------------------------------
 //
-//  ctr ╒═════ sponge ══════╕╒═══ cf_ops ══╕╒═══════ ld_ops ═══════╕╒═ hd_ops ╕╒═ ctx ══╕╒═ loop ═╕
-//   0    1    2    3    4    5    6    7    8    9    10   11   12   13   14   15   ..   ..   ..
-// ├────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┤
+//  ctr ╒═════ sponge ══════╕╒═ flow_ops ══╕╒═════════ user_ops ═════════╕╒═ ctx ══╕╒═ loop ═╕
+//   0    1    2    3    4    5    6    7    8    9    10   11   12   13   14   ..   ..   .. 
+// ├────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┴────┤
 
-const NUM_CF_OP_BITS        : usize = 3;
-const NUM_LD_OP_BITS        : usize = 5;
-const NUM_HD_OP_BITS        : usize = 2;
+const NUM_FLOW_OP_BITS      : usize = 3;
+const NUM_USER_OP_BITS      : usize = 6;
 
-const NUM_CF_OPS            : usize = 8;
-const NUM_LD_OPS            : usize = 32;
-const NUM_HD_OPS            : usize = 4;
+const NUM_FLOW_OPS          : usize = 8;
+const NUM_USER_OPS          : usize = 36;
 
 const OP_COUNTER_IDX        : usize = 0;
 const SPONGE_RANGE          : Range<usize> = Range { start:  1, end:  5 };
-const CF_OP_BITS_RANGE      : Range<usize> = Range { start:  5, end:  8 };
-const LD_OP_BITS_RANGE      : Range<usize> = Range { start:  8, end: 13 };
-const HD_OP_BITS_RANGE      : Range<usize> = Range { start: 13, end: 15 };
+const FLOW_OP_BITS_RANGE    : Range<usize> = Range { start:  5, end:  8 };
+const USER_OP_BITS_RANGE    : Range<usize> = Range { start:  8, end: 14 };
 
 // STACK LAYOUT
 // ------------------------------------------------------------------------------------------------

--- a/src/processor/decoder/mod.rs
+++ b/src/processor/decoder/mod.rs
@@ -248,7 +248,7 @@ impl Decoder {
         fill_register(&mut self.op_counter, self.step + 1, last_op_count);
 
         // set all bit registers to 0 to indicate NOOP operation
-        for register in self.flow_op_bits.iter_mut() { fill_register(register, self.step, field::ZERO); }
+        for register in self.flow_op_bits.iter_mut() { fill_register(register, self.step, field::ONE); }
         for register in self.user_op_bits.iter_mut() { fill_register(register, self.step, field::ZERO); }
 
         // for sponge and stack registers, just copy the value of the last state of the register

--- a/src/processor/mod.rs
+++ b/src/processor/mod.rs
@@ -196,15 +196,14 @@ mod tests {
         let trace_length = trace[0].len();
 
         assert_eq!(64, trace_length);
-        assert_eq!(17, trace.len());
+        assert_eq!(16, trace.len());
         let mut state = build_trace_state(trace.len(), ctx_depth, loop_depth) ;
         state.update_from_trace(&trace, trace_length - 1);
 
         assert_eq!(46, state.op_counter());
         assert_eq!(program.hash(), as_bytes(state.program_hash()));
-        assert_eq!([1, 1, 1], state.cf_op_bits());
-        assert_eq!([1, 1, 1, 1, 1], state.ld_op_bits());
-        assert_eq!([1, 1], state.hd_op_bits());
+        assert_eq!([0, 0, 0], state.flow_op_bits());
+        assert_eq!([0, 0, 0, 0, 0, 0], state.user_op_bits());
         assert_eq!([0], state.ctx_stack());
         assert_eq!([7, 15, 0, 0, 0, 0, 0, 0], state.user_stack());
     }
@@ -218,17 +217,15 @@ mod tests {
         let trace_length = trace[0].len();
 
         assert_eq!(64, trace_length);
-        assert_eq!(18, trace.len());
+        assert_eq!(17, trace.len());
 
         let mut state = build_trace_state(trace.len(), ctx_depth, loop_depth) ;
         state.update_from_trace(&trace, trace_length - 1);
         
         assert_eq!(60, state.op_counter());
         assert_eq!(program.hash(), as_bytes(state.program_hash()));
-        assert_eq!([1, 1, 1], state.cf_op_bits());
-        assert_eq!([1, 1, 1, 1, 1], state.ld_op_bits());
-        assert_eq!([1, 1], state.hd_op_bits());
-        assert_eq!([0], state.ctx_stack());
+        assert_eq!([0, 0, 0], state.flow_op_bits());
+        assert_eq!([0, 0, 0, 0, 0, 0], state.user_op_bits());
         assert_eq!([0], state.loop_stack());
         assert_eq!([7, 15, 0, 0, 0, 0, 0, 0], state.user_stack());
     }
@@ -244,16 +241,15 @@ mod tests {
         let trace_length = trace[0].len();
 
         assert_eq!(128, trace_length);
-        assert_eq!(19, trace.len());
+        assert_eq!(18, trace.len());
 
         let mut state = build_trace_state(trace.len(), ctx_depth, loop_depth) ;
         state.update_from_trace(&trace, trace_length - 1);
 
         assert_eq!(76, state.op_counter());
         assert_eq!(program.hash(), as_bytes(state.program_hash()));
-        assert_eq!([1, 1, 1], state.cf_op_bits());
-        assert_eq!([1, 1, 1, 1, 1], state.ld_op_bits());
-        assert_eq!([1, 1], state.hd_op_bits());
+        assert_eq!([0, 0, 0], state.flow_op_bits());
+        assert_eq!([0, 0, 0, 0, 0, 0], state.user_op_bits());
         assert_eq!([0], state.ctx_stack());
         assert_eq!([0], state.loop_stack());
         assert_eq!([24, 0, 0, 0, 0, 0, 0, 0], state.user_stack());
@@ -264,16 +260,15 @@ mod tests {
         let trace_length = trace[0].len();
 
         assert_eq!(128, trace_length);
-        assert_eq!(19, trace.len());
+        assert_eq!(18, trace.len());
 
         let mut state = build_trace_state(trace.len(), ctx_depth, loop_depth) ;
         state.update_from_trace(&trace, trace_length - 1);
 
         assert_eq!(92, state.op_counter());
         assert_eq!(program.hash(), as_bytes(state.program_hash()));
-        assert_eq!([1, 1, 1], state.cf_op_bits());
-        assert_eq!([1, 1, 1, 1, 1], state.ld_op_bits());
-        assert_eq!([1, 1], state.hd_op_bits());
+        assert_eq!([0, 0, 0], state.flow_op_bits());
+        assert_eq!([0, 0, 0, 0, 0, 0], state.user_op_bits());
         assert_eq!([0], state.ctx_stack());
         assert_eq!([0], state.loop_stack());
         assert_eq!([96, 3, 0, 0, 0, 0, 0, 0], state.user_stack());
@@ -290,16 +285,15 @@ mod tests {
         let trace_length = trace[0].len();
 
         assert_eq!(64, trace_length);
-        assert_eq!(18, trace.len());
+        assert_eq!(17, trace.len());
 
         let mut state = build_trace_state(trace.len(), ctx_depth, loop_depth) ;
         state.update_from_trace(&trace, trace_length - 1);
 
         assert_eq!(60, state.op_counter());
         assert_eq!(program.hash(), as_bytes(state.program_hash()));
-        assert_eq!([1, 1, 1], state.cf_op_bits());
-        assert_eq!([1, 1, 1, 1, 1], state.ld_op_bits());
-        assert_eq!([1, 1], state.hd_op_bits());
+        assert_eq!([0, 0, 0], state.flow_op_bits());
+        assert_eq!([0, 0, 0, 0, 0, 0], state.user_op_bits());
         assert_eq!([0], state.ctx_stack());
         assert_eq!([0], state.loop_stack());
         assert_eq!([15, 0, 0, 0, 0, 0, 0, 0], state.user_stack());
@@ -310,16 +304,15 @@ mod tests {
         let trace_length = trace[0].len();
 
         assert_eq!(128, trace_length);
-        assert_eq!(19, trace.len());
+        assert_eq!(18, trace.len());
 
         let mut state = build_trace_state(trace.len(), ctx_depth, loop_depth) ;
         state.update_from_trace(&trace, trace_length - 1);
 
         assert_eq!(75, state.op_counter());
         assert_eq!(program.hash(), as_bytes(state.program_hash()));
-        assert_eq!([1, 1, 1], state.cf_op_bits());
-        assert_eq!([1, 1, 1, 1, 1], state.ld_op_bits());
-        assert_eq!([1, 1], state.hd_op_bits());
+        assert_eq!([0, 0, 0], state.flow_op_bits());
+        assert_eq!([0, 0, 0, 0, 0, 0], state.user_op_bits());
         assert_eq!([0], state.ctx_stack());
         assert_eq!([0], state.loop_stack());
         assert_eq!([225, 0, 0, 0, 0, 0, 0, 0], state.user_stack());
@@ -330,16 +323,15 @@ mod tests {
         let trace_length = trace[0].len();
 
         assert_eq!(256, trace_length);
-        assert_eq!(19, trace.len());
+        assert_eq!(18, trace.len());
 
         let mut state = build_trace_state(trace.len(), ctx_depth, loop_depth) ;
         state.update_from_trace(&trace, trace_length - 1);
 
         assert_eq!(135, state.op_counter());
         assert_eq!(program.hash(), as_bytes(state.program_hash()));
-        assert_eq!([1, 1, 1], state.cf_op_bits());
-        assert_eq!([1, 1, 1, 1, 1], state.ld_op_bits());
-        assert_eq!([1, 1], state.hd_op_bits());
+        assert_eq!([0, 0, 0], state.flow_op_bits());
+        assert_eq!([0, 0, 0, 0, 0, 0], state.user_op_bits());
         assert_eq!([0], state.ctx_stack());
         assert_eq!([0], state.loop_stack());
         assert_eq!([43143988327398919500410556793212890625, 0, 0, 0, 0, 0, 0, 0], state.user_stack());

--- a/src/processor/stack/mod.rs
+++ b/src/processor/stack/mod.rs
@@ -76,6 +76,10 @@ impl Stack {
             OpCode::Read        => self.op_read(op_hint),
             OpCode::Read2       => self.op_read2(op_hint),
 
+            OpCode::MLoad       => self.op_noop(),  // TODO
+            OpCode::MStore      => self.op_noop(),  // TODO
+            OpCode::MemRR       => self.op_noop(),  // TODO
+
             OpCode::Dup         => self.op_dup(),
             OpCode::Dup2        => self.op_dup2(),
             OpCode::Dup4        => self.op_dup4(),
@@ -108,6 +112,8 @@ impl Stack {
             OpCode::BinAcc      => self.op_binacc(op_hint),
 
             OpCode::RescR       => self.op_rescr(),
+
+            OpCode::Future1     => self.op_noop(),
         }
     }
 

--- a/src/stark/constraints/decoder/mod.rs
+++ b/src/stark/constraints/decoder/mod.rs
@@ -29,12 +29,13 @@ mod tests;
 // ================================================================================================
 const NUM_OP_CONSTRAINTS: usize = 15;
 const OP_CONSTRAINT_DEGREES: [usize; NUM_OP_CONSTRAINTS] = [
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2,   // all op bits are binary
-    3,                              // op_counter should be incremented for HACC operations
-    8,                              // ld_ops and hd_ops cannot be all 0s
-    8,                              // when cf_ops are not all 0s, ld_ops and hd_ops must be all 1s
-    6,                              // VOID can be followed only by VOID
-    4,                              // operations happen on allowed step multiples
+    2, 2, 2, 2, 2, 2, 2, 2, 2,  // all op bits are binary
+    3,                          // op_counter should be incremented for HACC operations
+    7,                          // unless flow_op is HACC, user_op must be NOOP
+    4,                          // TODO
+    6,                          // TODO
+    6,                          // VOID can be followed only by VOID
+    4,                          // operations happen on allowed step multiples
 ];
 
 const NUM_SPONGE_CONSTRAINTS: usize = 4;

--- a/src/stark/constraints/decoder/mod.rs
+++ b/src/stark/constraints/decoder/mod.rs
@@ -137,16 +137,15 @@ impl Decoder {
 
         // evaluate constraints for flow control operations
         let result = &mut result[NUM_OP_CONSTRAINTS..];
-        let op_flags = current.cf_op_flags();
-
-        enforce_hacc (result, current, next, &ark, op_flags[FlowOps::Hacc.op_index() ]);
-        enforce_begin(result, current, next,       op_flags[FlowOps::Begin.op_index()]);
-        enforce_tend (result, current, next,       op_flags[FlowOps::Tend.op_index() ]);
-        enforce_fend (result, current, next,       op_flags[FlowOps::Fend.op_index() ]);
-        enforce_loop (result, current, next,       op_flags[FlowOps::Loop.op_index() ]);
-        enforce_wrap (result, current, next,       op_flags[FlowOps::Wrap.op_index() ]);
-        enforce_break(result, current, next,       op_flags[FlowOps::Break.op_index()]);
-        enforce_void (result, current, next,       op_flags[FlowOps::Void.op_index() ]);
+        
+        enforce_hacc (result, current, next, &ark, current.get_flow_op_flags(FlowOps::Hacc));
+        enforce_begin(result, current, next,       current.get_flow_op_flags(FlowOps::Begin));
+        enforce_tend (result, current, next,       current.get_flow_op_flags(FlowOps::Tend));
+        enforce_fend (result, current, next,       current.get_flow_op_flags(FlowOps::Fend));
+        enforce_loop (result, current, next,       current.get_flow_op_flags(FlowOps::Loop));
+        enforce_wrap (result, current, next,       current.get_flow_op_flags(FlowOps::Wrap));
+        enforce_break(result, current, next,       current.get_flow_op_flags(FlowOps::Break));
+        enforce_void (result, current, next,       current.get_flow_op_flags(FlowOps::Void));
     }
 
     /// Evaluates decoder transition constraints at the specified x coordinate and saves the
@@ -175,16 +174,15 @@ impl Decoder {
 
         // evaluate constraints for flow control operations
         let result = &mut result[NUM_OP_CONSTRAINTS..];
-        let op_flags = current.cf_op_flags();
 
-        enforce_hacc (result, current, next, &ark, op_flags[FlowOps::Hacc as usize]);
-        enforce_begin(result, current, next, op_flags[FlowOps::Begin as usize]);
-        enforce_tend (result, current, next, op_flags[FlowOps::Tend as usize]);
-        enforce_fend (result, current, next, op_flags[FlowOps::Fend as usize]);
-        enforce_loop (result, current, next, op_flags[FlowOps::Loop as usize]);
-        enforce_wrap (result, current, next, op_flags[FlowOps::Wrap as usize]);
-        enforce_break(result, current, next, op_flags[FlowOps::Break as usize]);
-        enforce_void (result, current, next, op_flags[FlowOps::Void as usize]);
+        enforce_hacc (result, current, next, &ark, current.get_flow_op_flags(FlowOps::Hacc));
+        enforce_begin(result, current, next,       current.get_flow_op_flags(FlowOps::Begin));
+        enforce_tend (result, current, next,       current.get_flow_op_flags(FlowOps::Tend));
+        enforce_fend (result, current, next,       current.get_flow_op_flags(FlowOps::Fend));
+        enforce_loop (result, current, next,       current.get_flow_op_flags(FlowOps::Loop));
+        enforce_wrap (result, current, next,       current.get_flow_op_flags(FlowOps::Wrap));
+        enforce_break(result, current, next,       current.get_flow_op_flags(FlowOps::Break));
+        enforce_void (result, current, next,       current.get_flow_op_flags(FlowOps::Void));
     }
 }
 

--- a/src/stark/constraints/decoder/op_bits.rs
+++ b/src/stark/constraints/decoder/op_bits.rs
@@ -36,7 +36,7 @@ pub fn enforce_op_bits(result: &mut [u128], current: &TraceState, next: &TraceSt
     // when cf_ops = hacc, operation counter should be incremented by 1;
     // otherwise, operation counter should remain the same
     let op_counter = current.op_counter();
-    let is_hacc = current.cf_op_flags()[FlowOps::Hacc.op_index()];
+    let is_hacc = current.get_flow_op_flags(FlowOps::Hacc);
     let hacc_transition = mul(add(op_counter, field::ONE), is_hacc);
     let rest_transition = mul(op_counter, binary_not(is_hacc));
     result[i] = are_equal(add(hacc_transition, rest_transition), next.op_counter());
@@ -51,31 +51,27 @@ pub fn enforce_op_bits(result: &mut [u128], current: &TraceState, next: &TraceSt
     result[i] = mul(cf_bit_sum, binary_not(mul(ld_bit_prod, hd_bit_prod)));
     i += 1;
     
-    let cf_op_flags = current.cf_op_flags();
-
     // VOID can be followed only by VOID
-    let current_void_flag = cf_op_flags[FlowOps::Void.op_index()];
-    let next_void_flag = next.cf_op_flags()[FlowOps::Void.op_index()];
+    let current_void_flag = current.get_flow_op_flags(FlowOps::Void);
+    let next_void_flag = next.get_flow_op_flags(FlowOps::Void);
     result[i] = mul(current_void_flag, binary_not(next_void_flag));
     i += 1;
 
-    let hd_op_flags = current.hd_op_flags();
-
     // BEGIN, LOOP, BREAK, and WRAP are allowed only on one less than multiple of 16
     let prefix_mask = masks[PREFIX_MASK_IDX];
-    result.agg_constraint(i, cf_op_flags[FlowOps::Begin.op_index()], prefix_mask);
-    result.agg_constraint(i, cf_op_flags[FlowOps::Loop.op_index()],  prefix_mask);
-    result.agg_constraint(i, cf_op_flags[FlowOps::Wrap.op_index()],  prefix_mask);
-    result.agg_constraint(i, cf_op_flags[FlowOps::Break.op_index()], prefix_mask);
+    result.agg_constraint(i, current.get_flow_op_flags(FlowOps::Begin), prefix_mask);
+    result.agg_constraint(i, current.get_flow_op_flags(FlowOps::Loop),  prefix_mask);
+    result.agg_constraint(i, current.get_flow_op_flags(FlowOps::Wrap),  prefix_mask);
+    result.agg_constraint(i, current.get_flow_op_flags(FlowOps::Break), prefix_mask);
 
     // TEND and FEND is allowed only on multiples of 16
     let base_cycle_mask = masks[CYCLE_MASK_IDX];
-    result.agg_constraint(i, cf_op_flags[FlowOps::Tend.op_index()], base_cycle_mask);
-    result.agg_constraint(i, cf_op_flags[FlowOps::Fend.op_index()], base_cycle_mask);
+    result.agg_constraint(i, current.get_flow_op_flags(FlowOps::Tend), base_cycle_mask);
+    result.agg_constraint(i, current.get_flow_op_flags(FlowOps::Fend), base_cycle_mask);
 
     // PUSH is allowed only on multiples of 8
     let push_cycle_mask = masks[PUSH_MASK_IDX];
-    result.agg_constraint(i, hd_op_flags[UserOps::Push.hd_index()], push_cycle_mask);
+    result.agg_constraint(i, current.get_user_op_flag(UserOps::Push), push_cycle_mask);
 }
 
 // TESTS

--- a/src/stark/constraints/decoder/op_bits.rs
+++ b/src/stark/constraints/decoder/op_bits.rs
@@ -11,25 +11,18 @@ pub fn enforce_op_bits(result: &mut [u128], current: &TraceState, next: &TraceSt
 {
     let mut i = 0;
 
-    // make sure all op bits are binary and compute their product/sum
+    // TODO: make sure all op bits are binary and compute their product/sum
     let mut cf_bit_sum = 0;
-    for &op_bit in current.cf_op_bits() {
+    for &op_bit in current.flow_op_bits() {
         result[i] = is_binary(op_bit);
         cf_bit_sum = add(cf_bit_sum, op_bit);
         i += 1;
     }
 
     let mut ld_bit_prod = 1;
-    for &op_bit in current.ld_op_bits() {
+    for &op_bit in current.user_op_bits() {
         result[i] = is_binary(op_bit);
         ld_bit_prod = mul(ld_bit_prod, op_bit);
-        i += 1;
-    }
-
-    let mut hd_bit_prod = 1;
-    for &op_bit in current.hd_op_bits() {
-        result[i] = is_binary(op_bit);
-        hd_bit_prod = mul(hd_bit_prod, op_bit);
         i += 1;
     }
 
@@ -44,11 +37,11 @@ pub fn enforce_op_bits(result: &mut [u128], current: &TraceState, next: &TraceSt
 
     // ld_ops and hd_ops can be all 0s at the first step, but cannot be all 0s
     // at any other step
-    result[i] = mul(op_counter, mul(binary_not(ld_bit_prod), binary_not(hd_bit_prod)));
+    result[i] = 0; // TODO mul(op_counter, mul(binary_not(ld_bit_prod), binary_not(hd_bit_prod)));
     i += 1;
 
     // when cf_ops are not all 0s, ld_ops and hd_ops must be all 1s
-    result[i] = mul(cf_bit_sum, binary_not(mul(ld_bit_prod, hd_bit_prod)));
+    result[i] = 0; // TODO mul(cf_bit_sum, binary_not(mul(ld_bit_prod, hd_bit_prod)));
     i += 1;
     
     // VOID can be followed only by VOID
@@ -204,12 +197,12 @@ mod tests {
     fn new_state(flow_op: u8, user_op: u8, op_counter: u128) -> TraceState {
         let mut state = TraceState::new(1, 0, 1);
     
-        let mut op_bits = [0; 10];
+        let mut op_bits = [0; 9];
         for i in 0..3 {
             op_bits[i] = ((flow_op as u128) >> i) & 1;
         }
     
-        for i in 0..7 {
+        for i in 0..6 {
             op_bits[i + 3] = ((user_op as u128) >> i) & 1;
         }
 
@@ -222,7 +215,7 @@ mod tests {
         let mut state = TraceState::new(1, 0, 1);
         state.set_op_bits([
             cf_bits[0], cf_bits[1], cf_bits[2],
-            u_bits[0], u_bits[1], u_bits[2], u_bits[3], u_bits[4], u_bits[5], u_bits[6]
+            u_bits[0], u_bits[1], u_bits[2], u_bits[3], u_bits[4], u_bits[5]
         ]);
         return state;
     }

--- a/src/stark/constraints/decoder/sponge.rs
+++ b/src/stark/constraints/decoder/sponge.rs
@@ -11,7 +11,7 @@ pub fn enforce_hacc(result: &mut [u128], current: &TraceState, next: &TraceState
 {
     // determine current op_value
     let stack_top = next.user_stack()[0];
-    let push_flag = current.hd_op_flags()[UserOps::Push.hd_index()];
+    let push_flag = current.get_user_op_flag(UserOps::Push);
     let op_value = mul(stack_top, push_flag);
 
     // evaluate the first half of Rescue round

--- a/src/stark/constraints/evaluator.rs
+++ b/src/stark/constraints/evaluator.rs
@@ -203,7 +203,7 @@ impl Evaluator {
 
         // make sure cf_bits are set to HACC (000)
         let mut cc_idx = 0;
-        let op_bits = current.cf_op_bits();
+        let op_bits = current.flow_op_bits();
         for i in 0..op_bits.len() {
             i_result = field::add(i_result, field::mul(op_bits[i], cc.op_bits[cc_idx]));
             result_adj = field::add(result_adj, field::mul(op_bits[i], cc.op_bits[cc_idx + 1]));
@@ -211,7 +211,7 @@ impl Evaluator {
         }
 
         // make sure low-degree op_bits are set to BEGIN (0000)
-        let op_bits = current.ld_op_bits();
+        let op_bits = current.user_op_bits();
         for i in 0..op_bits.len() {
             i_result = field::add(i_result, field::mul(op_bits[i], cc.op_bits[cc_idx]));
             result_adj = field::add(result_adj, field::mul(op_bits[i], cc.op_bits[cc_idx + 1]));
@@ -219,7 +219,7 @@ impl Evaluator {
         }
 
         // make sure high-degree op_bits are set to BEGIN (00)
-        let op_bits = current.hd_op_bits();
+        let op_bits = current.user_op_bits(); // TODO
         for i in 0..op_bits.len() {
             i_result = field::add(i_result, field::mul(op_bits[i], cc.op_bits[cc_idx]));
             result_adj = field::add(result_adj, field::mul(op_bits[i], cc.op_bits[cc_idx + 1]));
@@ -272,7 +272,7 @@ impl Evaluator {
 
         // make sure control flow op_bits are set VOID (111)
         let mut cc_idx = 0;
-        let op_bits = current.cf_op_bits();
+        let op_bits = current.flow_op_bits();
         for i in 0..op_bits.len() {
             let val = field::sub(op_bits[i], field::ONE);
             f_result = field::add(f_result, field::mul(val, cc.op_bits[cc_idx]));
@@ -281,7 +281,7 @@ impl Evaluator {
         }
         
         // make sure low-degree op_bits are set to NOOP (11111)
-        let op_bits = current.ld_op_bits();
+        let op_bits = current.user_op_bits();
         for i in 0..op_bits.len() {
             let val = field::sub(op_bits[i], field::ONE);
             f_result = field::add(f_result, field::mul(val, cc.op_bits[cc_idx]));
@@ -290,7 +290,7 @@ impl Evaluator {
         }
         
         // make sure high-degree op_bits are set to NOOP (11)
-        let op_bits = current.hd_op_bits();
+        let op_bits = current.user_op_bits(); // TODO
         for i in 0..op_bits.len() {
             let val = field::sub(op_bits[i], field::ONE);
             f_result = field::add(f_result, field::mul(val, cc.op_bits[cc_idx]));

--- a/src/stark/constraints/evaluator.rs
+++ b/src/stark/constraints/evaluator.rs
@@ -201,7 +201,7 @@ impl Evaluator {
             result_adj = field::add(result_adj, field::mul(sponge[i], cc.sponge[i * 2 + 1]));
         }
 
-        // make sure cf_bits are set to HACC (000)
+        // make sure flow op_bits are set to HACC (000)
         let mut cc_idx = 0;
         let op_bits = current.flow_op_bits();
         for i in 0..op_bits.len() {
@@ -210,19 +210,12 @@ impl Evaluator {
             cc_idx += 2;
         }
 
-        // make sure low-degree op_bits are set to BEGIN (0000)
+        // make sure user op_bits are set to BEGIN (111111)
         let op_bits = current.user_op_bits();
         for i in 0..op_bits.len() {
-            i_result = field::add(i_result, field::mul(op_bits[i], cc.op_bits[cc_idx]));
-            result_adj = field::add(result_adj, field::mul(op_bits[i], cc.op_bits[cc_idx + 1]));
-            cc_idx += 2;
-        }
-
-        // make sure high-degree op_bits are set to BEGIN (00)
-        let op_bits = current.user_op_bits(); // TODO
-        for i in 0..op_bits.len() {
-            i_result = field::add(i_result, field::mul(op_bits[i], cc.op_bits[cc_idx]));
-            result_adj = field::add(result_adj, field::mul(op_bits[i], cc.op_bits[cc_idx + 1]));
+            let val = field::sub(op_bits[i], field::ONE);
+            i_result = field::add(i_result, field::mul(val, cc.op_bits[cc_idx]));
+            result_adj = field::add(result_adj, field::mul(val, cc.op_bits[cc_idx + 1]));
             cc_idx += 2;
         }
 
@@ -280,21 +273,11 @@ impl Evaluator {
             cc_idx += 2;
         }
         
-        // make sure low-degree op_bits are set to NOOP (11111)
+        // make sure user op_bits are set to NOOP (000000)
         let op_bits = current.user_op_bits();
         for i in 0..op_bits.len() {
-            let val = field::sub(op_bits[i], field::ONE);
-            f_result = field::add(f_result, field::mul(val, cc.op_bits[cc_idx]));
-            result_adj = field::add(result_adj, field::mul(val, cc.op_bits[cc_idx + 1]));
-            cc_idx += 2;
-        }
-        
-        // make sure high-degree op_bits are set to NOOP (11)
-        let op_bits = current.user_op_bits(); // TODO
-        for i in 0..op_bits.len() {
-            let val = field::sub(op_bits[i], field::ONE);
-            f_result = field::add(f_result, field::mul(val, cc.op_bits[cc_idx]));
-            result_adj = field::add(result_adj, field::mul(val, cc.op_bits[cc_idx + 1]));
+            f_result = field::add(f_result, field::mul(op_bits[i], cc.op_bits[cc_idx]));
+            result_adj = field::add(result_adj, field::mul(op_bits[i], cc.op_bits[cc_idx + 1]));
             cc_idx += 2;
         }
         

--- a/src/stark/constraints/stack/mod.rs
+++ b/src/stark/constraints/stack/mod.rs
@@ -37,8 +37,8 @@ use hash::{ enforce_rescr };
 // CONSTANTS
 // ================================================================================================
 pub const NUM_AUX_CONSTRAINTS: usize = 2;
-const AUX_CONSTRAINT_DEGREES: [usize; NUM_AUX_CONSTRAINTS] = [7, 7];
-const STACK_TRANSITION_DEGREE: usize = 7; // degree for all stack register transition constraints
+const AUX_CONSTRAINT_DEGREES: [usize; NUM_AUX_CONSTRAINTS] = [8, 7];
+const STACK_TRANSITION_DEGREE: usize = 8; // degree for all stack register transition constraints
 
 // TYPES AND INTERFACES
 // ================================================================================================

--- a/src/stark/constraints/stack/mod.rs
+++ b/src/stark/constraints/stack/mod.rs
@@ -129,56 +129,53 @@ fn enforce_constraints(current: &TraceState, next: &TraceState, ark: &[u128], re
     let mut evaluations = vec![field::ZERO; old_stack.len()];
 
     // 1 ----- enforce constraints for low-degree operations --------------------------------------
-    let ld_flags = current.ld_op_flags();
-
+    
     // assertion operations
-    enforce_assert  (&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::Assert.ld_index()]);
-    enforce_asserteq(&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::AssertEq.ld_index()]);
+    enforce_assert  (&mut evaluations, aux, old_stack, new_stack, current.get_user_op_flag(OpCode::Assert));
+    enforce_asserteq(&mut evaluations, aux, old_stack, new_stack, current.get_user_op_flag(OpCode::AssertEq));
 
     // input operations
-    enforce_read    (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Read.ld_index()]);
-    enforce_read2   (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Read2.ld_index()]);
+    enforce_read    (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Read));
+    enforce_read2   (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Read2));
 
     // stack manipulation operations
-    enforce_dup     (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Dup.ld_index()]);
-    enforce_dup2    (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Dup2.ld_index()]);
-    enforce_dup4    (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Dup4.ld_index()]);
-    enforce_pad2    (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Pad2.ld_index()]);
+    enforce_dup     (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Dup));
+    enforce_dup2    (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Dup2));
+    enforce_dup4    (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Dup4));
+    enforce_pad2    (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Pad2));
 
-    enforce_drop    (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Drop.ld_index()]);
-    enforce_drop4   (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Drop4.ld_index()]);
+    enforce_drop    (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Drop));
+    enforce_drop4   (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Drop4));
     
-    enforce_swap    (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Swap.ld_index()]);
-    enforce_swap2   (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Swap2.ld_index()]);
-    enforce_swap4   (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Swap4.ld_index()]);
+    enforce_swap    (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Swap));
+    enforce_swap2   (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Swap2));
+    enforce_swap4   (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Swap4));
 
-    enforce_roll4   (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Roll4.ld_index()]);
-    enforce_roll8   (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Roll8.ld_index()]);
+    enforce_roll4   (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Roll4));
+    enforce_roll8   (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Roll8));
 
     // arithmetic and boolean operations
-    enforce_add     (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Add.ld_index()]);
-    enforce_mul     (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Mul.ld_index()]);
-    enforce_inv     (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Inv.ld_index()]);
-    enforce_neg     (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::Neg.ld_index()]);
-    enforce_not     (&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::Not.ld_index()]);
-    enforce_and     (&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::And.ld_index()]);
-    enforce_or      (&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::Or.ld_index()]);
+    enforce_add     (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Add));
+    enforce_mul     (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Mul));
+    enforce_inv     (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Inv));
+    enforce_neg     (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::Neg));
+    enforce_not     (&mut evaluations, aux, old_stack, new_stack, current.get_user_op_flag(OpCode::Not));
+    enforce_and     (&mut evaluations, aux, old_stack, new_stack, current.get_user_op_flag(OpCode::And));
+    enforce_or      (&mut evaluations, aux, old_stack, new_stack, current.get_user_op_flag(OpCode::Or));
     
     // comparison operations
-    enforce_eq      (&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::Eq.ld_index()]);
-    enforce_binacc  (&mut evaluations,      old_stack, new_stack, ld_flags[OpCode::BinAcc.ld_index()]);
+    enforce_eq      (&mut evaluations, aux, old_stack, new_stack, current.get_user_op_flag(OpCode::Eq));
+    enforce_binacc  (&mut evaluations,      old_stack, new_stack, current.get_user_op_flag(OpCode::BinAcc));
 
     // conditional selection operations
-    enforce_choose  (&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::Choose.ld_index()]);
-    enforce_choose2 (&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::Choose2.ld_index()]);
-    enforce_cswap2  (&mut evaluations, aux, old_stack, new_stack, ld_flags[OpCode::CSwap2.ld_index()]);
+    enforce_choose  (&mut evaluations, aux, old_stack, new_stack, current.get_user_op_flag(OpCode::Choose));
+    enforce_choose2 (&mut evaluations, aux, old_stack, new_stack, current.get_user_op_flag(OpCode::Choose2));
+    enforce_cswap2  (&mut evaluations, aux, old_stack, new_stack, current.get_user_op_flag(OpCode::CSwap2));
 
     // 2 ----- enforce constraints for high-degree operations --------------------------------------
-    let hd_flags = current.hd_op_flags();
-
-    enforce_push    (&mut evaluations,      old_stack, new_stack,      hd_flags[OpCode::Push.hd_index() ]);
-    enforce_cmp     (&mut evaluations,      old_stack, new_stack,      hd_flags[OpCode::Cmp.hd_index()  ]);
-    enforce_rescr   (&mut evaluations,      old_stack, new_stack, ark, hd_flags[OpCode::RescR.hd_index()]);
+    enforce_push    (&mut evaluations,      old_stack, new_stack,      current.get_user_op_flag(OpCode::Push));
+    enforce_cmp     (&mut evaluations,      old_stack, new_stack,      current.get_user_op_flag(OpCode::Cmp));
+    enforce_rescr   (&mut evaluations,      old_stack, new_stack, ark, current.get_user_op_flag(OpCode::RescR));
 
     // 3 ----- enforce constraints for composite operations ---------------------------------------
 
@@ -187,8 +184,8 @@ fn enforce_constraints(current: &TraceState, next: &TraceState, ark: &[u128], re
     // this results in flag degree of 7 for each operation, but since both operations enforce the
     // same constraints (the stack doesn't change), higher degree terms cancel out, and we
     // end up with overall constraint degree of (6 + 1 = 7) for both operations.
-    enforce_stack_copy(&mut evaluations, old_stack, new_stack, 0, current.begin_flag());
-    enforce_stack_copy(&mut evaluations, old_stack, new_stack, 0, current.noop_flag());
+    enforce_stack_copy(&mut evaluations, old_stack, new_stack, 0, current.get_user_op_flag(OpCode::Begin));
+    enforce_stack_copy(&mut evaluations, old_stack, new_stack, 0, current.get_user_op_flag(OpCode::Noop));
     
     // 4 ----- copy evaluations into the result ---------------------------------------------------
     result.copy_from_slice(&evaluations[..result.len()]);

--- a/src/stark/trace/mod.rs
+++ b/src/stark/trace/mod.rs
@@ -1,5 +1,6 @@
 mod trace_state;
 mod trace_table;
+mod op_flags;
 
 pub use trace_state::TraceState;
 pub use trace_table::TraceTable;

--- a/src/stark/trace/op_flags.rs
+++ b/src/stark/trace/op_flags.rs
@@ -1,0 +1,227 @@
+use crate::{
+    math::field,
+    processor::opcodes::{ FlowOps, UserOps },
+    NUM_FLOW_OP_BITS, NUM_FLOW_OPS,
+    NUM_USER_OP_BITS, NUM_USER_OPS
+};
+
+// TYPES AND INTERFACES
+// ================================================================================================
+
+pub struct OpFlags {
+    flow_ops    : [u128; NUM_FLOW_OPS],
+    user_ops    : [u128; NUM_USER_OPS],
+}
+
+// OP FLAGS IMPLEMENTATION
+// ================================================================================================
+
+impl OpFlags {
+
+    // CONSTRUCTOR
+    // --------------------------------------------------------------------------------------------
+    pub fn new() -> OpFlags {
+        return OpFlags {
+            flow_ops    : [0; NUM_FLOW_OPS],
+            user_ops    : [0; NUM_USER_OPS]
+        };
+    }
+
+    // FLAG GETTERS
+    // --------------------------------------------------------------------------------------------
+
+    pub fn get_flow_op_flag(&self, op: FlowOps) -> u128 {
+        return match op {
+            FlowOps::Hacc       => self.flow_ops[0],
+            FlowOps::Begin      => self.flow_ops[1],
+            FlowOps::Tend       => self.flow_ops[2],
+            FlowOps::Fend       => self.flow_ops[3],
+            FlowOps::Loop       => self.flow_ops[4],
+            FlowOps::Wrap       => self.flow_ops[5],
+            FlowOps::Break      => self.flow_ops[6],
+            FlowOps::Void       => self.flow_ops[7],
+        };
+    }
+
+    pub fn get_user_op_flag(&self, op: UserOps) -> u128 {
+        return match op {
+            UserOps::Noop       => self.user_ops[0],
+            UserOps::Assert     => self.user_ops[1],
+            UserOps::AssertEq   => self.user_ops[2],
+            UserOps::Drop       => self.user_ops[3],
+            UserOps::Drop4      => self.user_ops[4],
+            UserOps::Pad2       => self.user_ops[5],
+            UserOps::Dup        => self.user_ops[6],
+            UserOps::Dup2       => self.user_ops[7],
+            UserOps::Dup4       => self.user_ops[8],
+            UserOps::Read       => self.user_ops[9],
+            UserOps::Read2      => self.user_ops[10],
+            UserOps::Swap       => self.user_ops[11],
+            UserOps::Swap2      => self.user_ops[12],
+            UserOps::Swap4      => self.user_ops[13],
+            UserOps::Roll4      => self.user_ops[14],
+            UserOps::Roll8      => self.user_ops[15],
+
+            UserOps::Eq         => self.user_ops[16],
+            UserOps::Choose     => self.user_ops[17],
+            UserOps::Choose2    => self.user_ops[18],
+            UserOps::CSwap2     => self.user_ops[19],
+            UserOps::Add        => self.user_ops[20],
+            UserOps::Mul        => self.user_ops[21],
+            UserOps::And        => self.user_ops[22],
+            UserOps::Or         => self.user_ops[23],
+            UserOps::Inv        => self.user_ops[24],
+            UserOps::Neg        => self.user_ops[25],
+            UserOps::Not        => self.user_ops[26],
+            UserOps::BinAcc     => self.user_ops[27],
+            UserOps::MLoad      => self.user_ops[28],
+            UserOps::MStore     => self.user_ops[29],
+            UserOps::Future1    => self.user_ops[30],
+
+            UserOps::Push       => self.user_ops[31],
+            UserOps::Cmp        => self.user_ops[32],
+            UserOps::RescR      => self.user_ops[33],
+            UserOps::MemRR      => self.user_ops[34],
+
+            UserOps::Begin      => self.user_ops[35]
+        };
+    }
+
+    // FLAG SETTER
+    // --------------------------------------------------------------------------------------------
+
+    pub fn update(&mut self, flow_op_bits: &[u128; NUM_FLOW_OP_BITS], user_op_bits: &[u128; NUM_USER_OP_BITS]) {
+
+        // 1 ----- compute control flow op flags --------------------------------------------------
+
+        let not_0 = binary_not(flow_op_bits[0]);
+        let not_1 = binary_not(flow_op_bits[1]);
+        self.flow_ops[0] = field::mul(not_0, not_1);
+        self.flow_ops[1] = field::mul(flow_op_bits[0], not_1);
+        self.flow_ops[2] = field::mul(not_0, flow_op_bits[1]);
+        self.flow_ops[3] = field::mul(flow_op_bits[0], flow_op_bits[1]);
+        self.flow_ops.copy_within(0..4, 4);
+
+        let not_2 = binary_not(flow_op_bits[2]);
+        for i in 0..4 { self.flow_ops[i] = field::mul(self.flow_ops[i], not_2); }
+        for i in 4..8 { self.flow_ops[i] = field::mul(self.flow_ops[i], flow_op_bits[2]); }
+
+        // 2 ----- compute user op flags ----------------------------------------------------------
+
+        let not_0 = binary_not(user_op_bits[0]);
+        let not_1 = binary_not(user_op_bits[1]);
+        self.user_ops[0] = field::mul(not_0, not_1);
+        self.user_ops[1] = field::mul(user_op_bits[0], not_1);
+        self.user_ops[2] = field::mul(not_0, user_op_bits[1]);
+        self.user_ops[3] = field::mul(user_op_bits[0], user_op_bits[1]);
+        self.user_ops.copy_within(0..4, 4);
+
+        let not_2 = binary_not(user_op_bits[2]);
+        for i in 0..4 { self.user_ops[i] = field::mul(self.user_ops[i], not_2); }
+        for i in 4..8 { self.user_ops[i] = field::mul(self.user_ops[i], user_op_bits[2]); }
+        self.user_ops.copy_within(0..8, 8);
+
+        let not_3 = binary_not(user_op_bits[3]);
+        for i in 0..8  { self.user_ops[i] = field::mul(self.user_ops[i], not_3); }
+        for i in 8..16 { self.user_ops[i] = field::mul(self.user_ops[i], user_op_bits[3]); }
+
+        self.user_ops.copy_within(0..15, 16);
+
+        // all op_bits are 1's: for begin op only
+        let class_1 = field::mul(user_op_bits[4], user_op_bits[5]);
+        self.user_ops[35] = field::mul(self.user_ops[15], class_1); // begin
+
+        // class 2 ops: can be degree 5 or smaller
+        let not_4 = binary_not(user_op_bits[4]);
+        let class_2 = field::mul(not_4, user_op_bits[5]);
+        self.user_ops[31] = field::mul(user_op_bits[0], class_2);   // push
+        self.user_ops[32] = field::mul(user_op_bits[1], class_2);   // cmp
+        self.user_ops[33] = field::mul(user_op_bits[2], class_2);   // rescr
+        self.user_ops[34] = field::mul(user_op_bits[3], class_2);   // memrr
+        
+        // class 3 ops: can be degree 2 or smaller
+        let not_5 = binary_not(user_op_bits[5]);
+        let class_3 = field::mul(user_op_bits[4], not_5);
+        for i in 16..31 { self.user_ops[i] = field::mul(self.user_ops[i], class_3); }
+
+        // class 4 ops: must be degree 1
+        let class_4 = field::mul(not_4, not_5);
+        for i in 0..16 { self.user_ops[i] = field::mul(self.user_ops[i], class_4); }
+    }
+}
+
+impl PartialEq for OpFlags {
+    fn eq(&self, other: &Self) -> bool {
+        return self.flow_ops == other.flow_ops
+            && self.user_ops.to_vec() == other.user_ops.to_vec();
+    }
+}
+
+// HELPER FUNCTIONS
+// ================================================================================================
+#[inline(always)]
+fn binary_not(v: u128) -> u128 {
+    return field::sub(field::ONE, v);
+}
+
+// TESTS
+// ================================================================================================
+#[cfg(test)]
+mod tests {
+
+    use std::convert::TryFrom;
+    use super::{ NUM_FLOW_OP_BITS, NUM_USER_OP_BITS };
+    
+    #[test]
+    fn flow_ops() {
+        let mut flags = super::OpFlags::new();
+        for i in 0..8 {
+            match super::UserOps::try_from(i) {
+                Ok(_) => {
+                    let mut flow_op_bits = [0; NUM_FLOW_OP_BITS];
+                    for j in 0..NUM_FLOW_OP_BITS {
+                        flow_op_bits[j] = ((i >> j) & 1) as u128;
+                    }
+
+                    flags.update(&flow_op_bits, &[0, 0, 0, 0, 0, 0]);
+
+                    let mut flag_count = 0;
+                    for flag in flags.flow_ops.to_vec() {
+                        if flag == 1 { flag_count += 1; }
+                    }
+
+                    // one and only one flag can be set for each valid operation
+                    assert_eq!(flag_count, 1);
+                },
+                Err(_) => ()
+            }
+        }
+    }
+
+    #[test]
+    fn user_ops() {
+        let mut flags = super::OpFlags::new();
+        for i in 0..64 {
+            match super::UserOps::try_from(i) {
+                Ok(_) => {
+                    let mut user_op_bits = [0; NUM_USER_OP_BITS];
+                    for j in 0..NUM_USER_OP_BITS {
+                        user_op_bits[j] = ((i >> j) & 1) as u128;
+                    }
+
+                    flags.update(&[0, 0, 0], &user_op_bits);
+
+                    let mut flag_count = 0;
+                    for flag in flags.user_ops.to_vec() {
+                        if flag == 1 { flag_count += 1; }
+                    }
+
+                    // one and only one flag can be set for each valid operation
+                    assert_eq!(flag_count, 1);
+                },
+                Err(_) => ()
+            }
+        }
+    }
+
+}

--- a/src/stark/utils/coefficients.rs
+++ b/src/stark/utils/coefficients.rs
@@ -6,13 +6,13 @@ use crate::{
     SPONGE_WIDTH,
     MAX_CONTEXT_DEPTH, MAX_LOOP_DEPTH, MAX_STACK_DEPTH,
     MIN_CONTEXT_DEPTH, MIN_LOOP_DEPTH, MIN_STACK_DEPTH,
-    NUM_CF_OP_BITS, NUM_LD_OP_BITS, NUM_HD_OP_BITS,
+    NUM_FLOW_OP_BITS, NUM_USER_OP_BITS,
     stark::constraints::{ NUM_STATIC_DECODER_CONSTRAINTS, NUM_AUX_STACK_CONSTRAINTS },
 };
 
 // CONSTANTS
 // ================================================================================================
-const NUM_OP_BITS: usize = NUM_CF_OP_BITS + NUM_LD_OP_BITS + NUM_HD_OP_BITS;
+const NUM_OP_BITS: usize = NUM_FLOW_OP_BITS + NUM_USER_OP_BITS;
 const MAX_USER_STACK_IO_CONSTRAINTS: usize = MAX_PUBLIC_INPUTS; // same as MAX_OUTPUTS
 const NUM_BOUNDARY_CONSTRAINTS: usize =
     1   // for op_counter


### PR DESCRIPTION
This PR will attempt to add support for random access memory. This requires:

- [ ] Move `PUSH` operation out of high-degree operation class into its own class.
- [ ] Add `MEMRR` operation to high-degree operation class.
- [ ] Add memory state register.
- [ ] Add `MLOAD` and `MSTORE` machine instructions to low-degree instruction class.
- [ ] Define `load` and `store` assembly instructions.
- [ ] Update external interfaces.
- [ ] Update documentation.