### PR TITLE
Make uninit_vector function unsafe

### DIFF
--- a/src/math/field.rs
+++ b/src/math/field.rs
@@ -163,7 +163,7 @@ pub fn inv(x: u128) -> u128 {
 
 /// Computes multiplicative inverses of all slice elements using batch inversion method.
 pub fn inv_many(values: &[u128]) -> Vec<u128> {
-    let mut result = uninit_vector(values.len());
+    let mut result = unsafe { uninit_vector(values.len()) };
     inv_many_fill(values, &mut result);
     return result;
 }
@@ -235,7 +235,7 @@ pub fn get_root_of_unity(order: usize) -> u128 {
 
 /// Generates a vector with values [1, b, b^2, b^3, b^4, ..., b^length].
 pub fn get_power_series(b: u128, length: usize) -> Vec<u128> {
-    let mut result = uninit_vector(length);
+    let mut result = unsafe { uninit_vector(length) };
     result[0] = ONE;
     for i in 1..result.len() {
         result[i] = mul(result[i - 1], b);

--- a/src/math/parallel.rs
+++ b/src/math/parallel.rs
@@ -14,7 +14,7 @@ pub fn add(a: &[u128], b: &[u128], num_threads: usize) -> Vec<u128> {
     let batch_size = n / num_threads;
 
     // allocate space for the results
-    let mut result = uninit_vector(n);
+    let mut result = unsafe { uninit_vector(n) };
 
     // add batches of values in separate threads
     thread::scope(|s| {
@@ -88,7 +88,7 @@ pub fn mul(a: &[u128], b: &[u128], num_threads: usize) -> Vec<u128> {
     let batch_size = n / num_threads;
 
     // allocate space for the results
-    let mut result = uninit_vector(n);
+    let mut result = unsafe { uninit_vector(n) };
 
     // multiply batches of values in separate threads
     thread::scope(|s| {
@@ -159,7 +159,7 @@ pub fn inv(values: &[u128], num_threads: usize) -> Vec<u128> {
     let batch_size = n / num_threads;
 
     // allocate space for the results
-    let result = uninit_vector(n);
+    let result = unsafe { uninit_vector(n) };
 
     // break up the values into batches and invert each batch in a separate thread
     thread::scope(|s| {

--- a/src/math/polynom.rs
+++ b/src/math/polynom.rs
@@ -259,7 +259,7 @@ pub fn infer_degree(evaluations: &[u128]) -> usize {
 // ================================================================================================
 fn get_zero_roots(xs: &[u128]) -> Vec<u128> {
     let mut n = xs.len() + 1;
-    let mut result = uninit_vector(n);
+    let mut result = unsafe { uninit_vector(n) };
     
     n -= 1;
     result[n] = field::ONE;

--- a/src/math/quartic.rs
+++ b/src/math/quartic.rs
@@ -138,7 +138,7 @@ pub fn transpose(vector: &[u128], stride: usize) -> Vec<[u128; 4]> {
     assert!(vector.len() % (4 * stride) == 0, "vector length must be divisible by {}", 4 * stride);
     let row_count = vector.len() / (4 * stride);
 
-    let mut result = to_quartic_vec(uninit_vector(row_count * 4));
+    let mut result = to_quartic_vec(unsafe { uninit_vector(row_count * 4) });
     for i in 0..row_count {
         result[i] = [
             vector[i * stride],

--- a/src/stark/constraints/constraint_table.rs
+++ b/src/stark/constraints/constraint_table.rs
@@ -20,9 +20,9 @@ impl ConstraintTable {
         let evaluation_domain_size = evaluator.domain_size();
         return ConstraintTable {
             evaluator       : evaluator,
-            i_evaluations   : uninit_vector(evaluation_domain_size),
-            f_evaluations   : uninit_vector(evaluation_domain_size),
-            t_evaluations   : uninit_vector(evaluation_domain_size),
+            i_evaluations   : unsafe { uninit_vector(evaluation_domain_size) },
+            f_evaluations   : unsafe { uninit_vector(evaluation_domain_size) },
+            t_evaluations   : unsafe { uninit_vector(evaluation_domain_size) },
         };
     }
 
@@ -59,7 +59,7 @@ impl ConstraintTable {
         #[cfg(debug_assertions)]
         self.validate_transition_degrees();
         
-        let mut combined_poly = uninit_vector(self.evaluation_domain_size());
+        let mut combined_poly = unsafe { uninit_vector(self.evaluation_domain_size()) };
         
         // 1 ----- boundary constraints for the initial step --------------------------------------
         // interpolate initial step boundary constraint combination into a polynomial, divide the 

--- a/src/stark/constraints/evaluator.rs
+++ b/src/stark/constraints/evaluator.rs
@@ -54,7 +54,7 @@ impl Evaluator {
         // of transition constraints
         let domain_size = trace_length * extension_factor;
         let t_evaluations = if cfg!(debug_assertions) {
-            t_constraint_degrees.iter().map(|_| uninit_vector(domain_size)).collect()
+            t_constraint_degrees.iter().map(|_| unsafe { uninit_vector(domain_size) }).collect()
         }
         else {
             Vec::new()

--- a/src/stark/fri/utils.rs
+++ b/src/stark/fri/utils.rs
@@ -14,7 +14,7 @@ pub fn get_augmented_positions(positions: &[usize], column_length: usize) -> Vec
 }
 
 pub fn hash_values(values: &Vec<[u128; 4]>, hash: HashFunction) -> Vec<[u8; 32]> {
-    let mut result: Vec<[u8; 32]> = uninit_vector(values.len());
+    let mut result: Vec<[u8; 32]> = unsafe { uninit_vector(values.len()) };
     for i in 0..values.len() {
         hash(as_bytes(&values[i]), &mut result[i]);
     }

--- a/src/stark/proof.rs
+++ b/src/stark/proof.rs
@@ -91,7 +91,7 @@ impl StarkProof {
     pub fn trace_proof(&self) -> BatchMerkleProof {
 
         let hash = self.options.hash_fn();
-        let mut hashed_states = uninit_vector::<[u8; 32]>(self.trace_evaluations.len());
+        let mut hashed_states = unsafe { uninit_vector::<[u8; 32]>(self.trace_evaluations.len()) };
         for i in 0..self.trace_evaluations.len() {
             hash(as_bytes(&self.trace_evaluations[i]), &mut hashed_states[i]);
         }

--- a/src/stark/trace/trace_table.rs
+++ b/src/stark/trace/trace_table.rs
@@ -173,7 +173,7 @@ impl TraceTable {
     /// form a single leaf value.
     pub fn build_merkle_tree(&self, hash: HashFunction) -> MerkleTree {
         let mut trace_state = vec![field::ZERO; self.register_count()];
-        let mut hashed_states = uninit_vector::<[u8; 32]>(self.domain_size());
+        let mut hashed_states = unsafe { uninit_vector::<[u8; 32]>(self.domain_size()) };
         // TODO: this loop should be parallelized
         for i in 0..self.domain_size() {
             for j in 0..trace_state.len() {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,9 +7,11 @@ pub mod sponge;
 
 // VECTOR FUNCTIONS
 // ================================================================================================
-pub fn uninit_vector<T>(length: usize) -> Vec<T> {
+/// # Safety
+/// Using values from the returned vector before initializing them will lead to undefined behavior.
+pub unsafe fn uninit_vector<T>(length: usize) -> Vec<T> {
     let mut vector = Vec::with_capacity(length);
-    unsafe { vector.set_len(length); }
+    vector.set_len(length);
     return vector;
 }
 


### PR DESCRIPTION
Hello, I found a soundness issue in this crate.
https://github.com/GuildOfWeavers/distaff/blob/fad92ce592921e671e72f93cd0078e867350860d/src/utils/mod.rs#L10-L14
The unsafe function called needs to ensure that the parameter must be:

- new_len must be less than or equal to capacity().
- The elements at old_len..new_len must be initialized.

[https://doc.rust-lang.org/std/vec/struct.Vec.html#method.set_len](url)
and the developer who calls the uninit_vector function may not notice this safety requirement.
Marking them unsafe also means that callers must make sure they know what they're doing.
A similar situation to the above is as follows:
[https://github.com/facebook/winterfell/pull/30](url)